### PR TITLE
fix(library): album card layout

### DIFF
--- a/app/(authed)/library/library-list.tsx
+++ b/app/(authed)/library/library-list.tsx
@@ -82,7 +82,7 @@ const AlbumCard = memo(function AlbumCard({ album, isCompact, isActive, isPlayin
     return (
         <button
             onClick={onClick}
-            className="group flex flex-col gap-2 rounded-lg p-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-900"
+            className="group flex flex-col gap-2 rounded-lg p-2 text-left transition-colors hover:bg-gray-100 dark:hover:bg-gray-900 w-full"
         >
             <div className="relative w-full aspect-square">
                 {largeArt
@@ -878,7 +878,7 @@ export default function LibraryList({ initialSongs }: { initialSongs: LibrarySon
             {/* Sections */}
             {viewMode === 'albums'
                 ? sortLetterEntries([...albumGrouped.entries()]).map(([letter, albums]) => (
-                    <div key={letter} ref={el => { sectionRefs.current[letter] = el }} data-letter={letter} className="scroll-mt-24 cv-auto">
+                    <div key={letter} ref={el => { sectionRefs.current[letter] = el }} data-letter={letter} className="scroll-mt-24">
                         <div className="md:sticky md:top-24 z-30 bg-background px-1 py-0.5 mb-1">
                             <span className="text-xs font-bold text-sky-500 tracking-widest">{letter}</span>
                         </div>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Add `w-full` to desktop `AlbumCard` button — without it, flex containers in some browsers computed width from text min-content rather than the grid cell, causing variable-sized overlapping cards
- Drop `cv-auto` from album letter sections — `contain-intrinsic-size: 600px` doesn't hold for a dense multi-column grid where sections can be much taller, causing section overlap

Pre-existing bug, not introduced by #7.