### PR TITLE
fix(player): visibility-gated silent loop syncs iOS widget on in-app pause

### DIFF
--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,41 +445,39 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
-    // In-app pause: clean audio.pause(). No silent loop — we want the iOS Now
-    // Playing widget to show "paused" in sync with our UI. Trade-off: after ~10s
-    // backgrounded, iOS releases the audio session and the lock-screen play
-    // button goes unresponsive (user must unlock and tap play in the app to
-    // resume). The silent-loop keep-alive is preserved on the lock-screen
-    // 'pause' MediaSession action handler, where iOS's own gesture commits the
-    // widget to "paused" before we run.
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
+        // Already in silent-loop pause — nothing to do.
         if (sessionKeepAliveRef.current) {
-            // Tear down the silent loop and hard-pause at the pinned position.
-            // Reaches here when the user pressed pause-on-lock-screen (silent
-            // loop running) and then opens the app and presses pause in-UI.
-            const realSrc = savedSrcBeforeSilenceRef.current
-            const realPos = pinnedPosRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            if (realSrc) {
-                audio.src = realSrc
-                pendingPosition.current = realPos
-                shouldPlayRef.current = false
-                audio.load()
-            }
             setIsPlaying(false)
-            if ('mediaSession' in navigator) {
-                navigator.mediaSession.playbackState = 'paused'
-                try { navigator.mediaSession.setPositionState() } catch {}
-            }
             return
         }
-        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
-        audio.pause()
+        // No real source loaded yet — fall back to a hard pause.
+        if (!audio.src || audio.paused) {
+            audio.pause()
+            setIsPlaying(false)
+            return
+        }
+        const realPos = audio.currentTime
+        const realDur = audio.duration
+        savePosition(current, realPos)
+        pendingPosition.current = realPos
+        pinnedPosRef.current = realPos
+        pinnedDurRef.current = realDur
+        savedSrcBeforeSilenceRef.current = audio.src
+        sessionKeepAliveRef.current = true
+        audio.src = SILENT_LOOP_SRC
+        audio.loop = true
+        audio.load()
+        audio.play().catch(() => {
+            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
+            sessionKeepAliveRef.current = false
+            audio.loop = false
+            audio.pause()
+        })
         setIsPlaying(false)
+        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -467,10 +467,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         pinnedDurRef.current = realDur
         savedSrcBeforeSilenceRef.current = audio.src
         sessionKeepAliveRef.current = true
-        // Declare paused to MediaSession BEFORE starting the silent loop so iOS
-        // sees the paused state when the audio session activates, instead of
-        // snapshotting "playing" off the silent-loop play event.
-        pinLockScreenPosition(realPos, realDur)
         audio.src = SILENT_LOOP_SRC
         audio.loop = true
         audio.load()
@@ -481,6 +477,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             audio.pause()
         })
         setIsPlaying(false)
+        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
@@ -837,7 +834,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             pinnedDurRef.current = realDur
             savedSrcBeforeSilenceRef.current = audio.src
             sessionKeepAliveRef.current = true
-            pinLockScreenPosition(realPos, realDur)
             audio.src = SILENT_LOOP_SRC
             audio.loop = true
             audio.load()
@@ -847,6 +843,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                 audio.pause()
             })
             setIsPlaying(false)
+            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -467,6 +467,13 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         pinnedDurRef.current = realDur
         savedSrcBeforeSilenceRef.current = audio.src
         sessionKeepAliveRef.current = true
+        // Fire a real 'pause' event + declare paused BEFORE swapping to the
+        // silent track. The lock-screen 'pause' MediaSession action handler
+        // works because iOS's own gesture commits the Now Playing widget to
+        // paused; mimic that for in-app pause by giving iOS a real pause
+        // signal on the audio element first.
+        audio.pause()
+        pinLockScreenPosition(realPos, realDur)
         audio.src = SILENT_LOOP_SRC
         audio.loop = true
         audio.load()
@@ -477,7 +484,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             audio.pause()
         })
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
@@ -834,6 +840,8 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             pinnedDurRef.current = realDur
             savedSrcBeforeSilenceRef.current = audio.src
             sessionKeepAliveRef.current = true
+            audio.pause()
+            pinLockScreenPosition(realPos, realDur)
             audio.src = SILENT_LOOP_SRC
             audio.loop = true
             audio.load()
@@ -843,7 +851,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                 audio.pause()
             })
             setIsPlaying(false)
-            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,6 +445,44 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
+    // Swap audio element to the silent loop (preserves iOS audio session). Same
+    // single-element approach main has always used — keeps iOS's gesture-priority
+    // widget commit intact (a separate <audio> element breaks it).
+    function kickSilentLoop() {
+        const audio = audioRef.current
+        if (!audio || sessionKeepAliveRef.current) return
+        savedSrcBeforeSilenceRef.current = audio.src
+        sessionKeepAliveRef.current = true
+        audio.src = SILENT_LOOP_SRC
+        audio.loop = true
+        audio.load()
+        audio.play().catch(() => {
+            sessionKeepAliveRef.current = false
+            savedSrcBeforeSilenceRef.current = null
+            audio.loop = false
+        })
+        pinLockScreenPosition(pinnedPosRef.current, pinnedDurRef.current)
+    }
+
+    // Restore real song src from silent loop. autoplay=true for resume,
+    // false when transitioning back to visible (user is logically paused).
+    function stopSilentLoop(autoplay: boolean) {
+        if (!sessionKeepAliveRef.current) return
+        const audio = audioRef.current
+        const realSrc = savedSrcBeforeSilenceRef.current
+        sessionKeepAliveRef.current = false
+        savedSrcBeforeSilenceRef.current = null
+        if (audio) {
+            audio.loop = false
+            if (realSrc) {
+                audio.src = realSrc
+                shouldPlayRef.current = autoplay
+                audio.load()
+            }
+        }
+        unpinLockScreenPosition()
+    }
+
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
@@ -465,36 +503,26 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         pendingPosition.current = realPos
         pinnedPosRef.current = realPos
         pinnedDurRef.current = realDur
-        savedSrcBeforeSilenceRef.current = audio.src
-        sessionKeepAliveRef.current = true
-        audio.src = SILENT_LOOP_SRC
-        audio.loop = true
-        audio.load()
-        audio.play().catch(() => {
-            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
-            sessionKeepAliveRef.current = false
-            audio.loop = false
+        // Page visible (in-app pause): clean pause so widget syncs to "paused".
+        // Page hidden (lock-screen pause from another path): silent-loop swap so
+        // session stays warm. visibilitychange:hidden will kick silent loop later.
+        if (typeof document !== 'undefined' && document.hidden) {
+            kickSilentLoop()
+        } else {
             audio.pause()
-        })
+            if ('mediaSession' in navigator) {
+                navigator.mediaSession.playbackState = 'paused'
+            }
+        }
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
         const audio = audioRef.current
         if (!audio) return
         if (sessionKeepAliveRef.current) {
-            const realSrc = savedSrcBeforeSilenceRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            if (realSrc) {
-                audio.src = realSrc
-                shouldPlayRef.current = true
-                audio.load()
-            }
+            stopSilentLoop(true)
             setIsPlaying(true)
-            unpinLockScreenPosition()
             return
         }
         setIsPlaying(true)
@@ -798,17 +826,8 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             const audio = audioRef.current
             if (!audio) return
             if (sessionKeepAliveRef.current) {
-                const realSrc = savedSrcBeforeSilenceRef.current
-                sessionKeepAliveRef.current = false
-                savedSrcBeforeSilenceRef.current = null
-                audio.loop = false
-                if (realSrc) {
-                    audio.src = realSrc
-                    shouldPlayRef.current = true
-                    audio.load()
-                }
+                stopSilentLoop(true)
                 setIsPlaying(true)
-                unpinLockScreenPosition()
                 return
             }
             setIsPlaying(true)
@@ -832,21 +851,22 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             pendingPosition.current = realPos
             pinnedPosRef.current = realPos
             pinnedDurRef.current = realDur
-            savedSrcBeforeSilenceRef.current = audio.src
-            sessionKeepAliveRef.current = true
-            audio.src = SILENT_LOOP_SRC
-            audio.loop = true
-            audio.load()
-            audio.play().catch(() => {
-                sessionKeepAliveRef.current = false
-                audio.loop = false
+            // Lock-screen pause is the iOS gesture path — page is hidden, so
+            // silent-loop swap (main's behavior). iOS gesture priority should
+            // keep the widget on "paused" through the src transition.
+            if (typeof document !== 'undefined' && document.hidden) {
+                kickSilentLoop()
+            } else {
+                // Hardware/media-key pause from foreground (rare). Clean pause.
                 audio.pause()
-            })
+                navigator.mediaSession.playbackState = 'paused'
+            }
             setIsPlaying(false)
-            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)
+    // kickSilentLoop / stopSilentLoop only touch refs — stale closures are fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [current, skipNext, skipPrev, savePosition])
 
     useEffect(() => {
@@ -877,44 +897,44 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [current, skipPrev, skipNext])
 
-    // iOS suspends backgrounded tabs after ~20s, killing the silent loop that
-    // keeps the audio session warm. When the user reopens the app (especially
-    // in full-screen mode where there's no pull-to-refresh), the audio element
-    // can be in a stuck buffering state with no path back. Detect that on
-    // visibilitychange and reset the UI to "ready to play" so a user tap
-    // initiates a fresh load instead of staring at a spinner.
+    // Visibility-gated silent loop:
+    // - hidden + audio cleanly paused → kick silent loop to keep session warm
+    // - visible → stop silent loop so widget can sync to "paused"
+    //
+    // Also handles the iOS-suspension case: if silent loop died during
+    // backgrounding, real-src restore + clearing state when foregrounded.
     useEffect(() => {
         function onVisible() {
-            if (document.hidden) return
+            const audio = audioRef.current
+            if (!audio) return
 
-            // iOS sometimes forgets the previoustrack/nexttrack handlers after
-            // backgrounded suspension, falling back to ±10s seek markers on the
-            // lock-screen. Re-bind on every re-foreground.
+            if (document.hidden) {
+                // Going hidden while logically paused: silent loop kicks in to
+                // preserve lock-screen play. iOS may flip the widget to
+                // "playing" since this isn't a user gesture, but the session
+                // stays warm and lock-screen controls work.
+                if (sessionKeepAliveRef.current) return
+                if (!audio.src || !audio.paused) return
+                kickSilentLoop()
+                return
+            }
+
+            // Becoming visible. Re-bind track handlers (iOS forgets them after
+            // backgrounded suspension) and stop silent loop so widget re-syncs.
             if ('mediaSession' in navigator) {
                 navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
                 navigator.mediaSession.setActionHandler('nexttrack', skipNext)
             }
-
-            const audio = audioRef.current
-            if (!audio) return
-            if (!sessionKeepAliveRef.current) return
-            if (!audio.paused) return  // silent loop still alive — nothing to do
-
-            const realSrc = savedSrcBeforeSilenceRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            shouldPlayRef.current = false
-            if (realSrc) {
-                audio.src = realSrc
-                audio.load()
+            if (sessionKeepAliveRef.current) {
+                stopSilentLoop(false)
+                setIsPlaying(false)
+                setIsBuffering(false)
             }
-            setIsPlaying(false)
-            setIsBuffering(false)
-            unpinLockScreenPosition()
         }
         document.addEventListener('visibilitychange', onVisible)
         return () => document.removeEventListener('visibilitychange', onVisible)
+    // kickSilentLoop / stopSilentLoop only touch refs — stale closures are fine.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [skipPrev, skipNext])
 
     useEffect(() => {

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,6 +445,40 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
+    // Build & set MediaMetadata for the current song. Called when current
+    // changes, and again on resume to restore the Now Playing widget after
+    // an in-app pause cleared it.
+    function setMediaSessionMetadata(song: PlayableSong) {
+        if (!song.properties || !('mediaSession' in navigator)) return
+        const p = song.properties
+        const origin = typeof window !== 'undefined' ? window.location.origin : ''
+        const sizes = [128, 192, 256, 384, 512]
+        const artwork: { src: string; sizes: string; type: string }[] = []
+        for (const s of sizes) {
+            const url = songArtworkUrl(song.uuid, song.artwork_cached, p.artworkUrl100, s)
+            if (!url) continue
+            const absolute = url.startsWith('/') ? `${origin}${url}` : url
+            artwork.push({ src: absolute, sizes: `${s}x${s}`, type: 'image/jpeg' })
+        }
+        navigator.mediaSession.metadata = new MediaMetadata({
+            title: p.trackName,
+            artist: p.artistName,
+            album: p.collectionName,
+            artwork,
+        })
+    }
+
+    // In-app pause clears the iOS Now Playing widget. Setting both metadata
+    // and playbackState lets iOS hide the widget entirely (or at least show
+    // a neutral state) instead of the misleading "playing" indicator that
+    // sticks when the audio element is paused but iOS hasn't refreshed.
+    function clearMediaSessionForInAppPause() {
+        if (!('mediaSession' in navigator)) return
+        navigator.mediaSession.metadata = null
+        navigator.mediaSession.playbackState = 'none'
+        try { navigator.mediaSession.setPositionState() } catch {}
+    }
+
     // In-app pause is a clean audio.pause(). No silent-loop keep-alive here:
     // iOS Now Playing reads element.paused = true and shows "paused" in sync
     // with our UI. The lock-screen 'pause' MediaSession action handler still
@@ -474,16 +508,13 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                 audio.load()
             }
             setIsPlaying(false)
-            if ('mediaSession' in navigator) {
-                navigator.mediaSession.playbackState = 'paused'
-                try { navigator.mediaSession.setPositionState() } catch {}
-            }
+            clearMediaSessionForInAppPause()
             return
         }
         if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
         audio.pause()
         setIsPlaying(false)
-        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused'
+        clearMediaSessionForInAppPause()
     }
 
     function resume() {
@@ -503,6 +534,9 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             unpinLockScreenPosition()
             return
         }
+        // Restore Now Playing widget after an in-app pause cleared it.
+        if (current) setMediaSessionMetadata(current)
+        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'playing'
         setIsPlaying(true)
         audio.play().catch(() => {})
     }
@@ -779,27 +813,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         if (!current?.properties || !('mediaSession' in navigator)) return
-        const p = current.properties
-        // iOS lock screen prefers several sizes; provide both small and large so the OS picks what fits.
-        // Use the absolute origin for cached artwork URLs since Media Session needs fully-qualified URLs.
-        const origin = typeof window !== 'undefined' ? window.location.origin : ''
-        const buildArtwork = (): { src: string; sizes: string; type: string }[] => {
-            const sizes = [128, 192, 256, 384, 512]
-            const out: { src: string; sizes: string; type: string }[] = []
-            for (const s of sizes) {
-                const url = songArtworkUrl(current.uuid, current.artwork_cached, p.artworkUrl100, s)
-                if (!url) continue
-                const absolute = url.startsWith('/') ? `${origin}${url}` : url
-                out.push({ src: absolute, sizes: `${s}x${s}`, type: 'image/jpeg' })
-            }
-            return out
-        }
-        navigator.mediaSession.metadata = new MediaMetadata({
-            title: p.trackName,
-            artist: p.artistName,
-            album: p.collectionName,
-            artwork: buildArtwork(),
-        })
+        setMediaSessionMetadata(current)
         navigator.mediaSession.setActionHandler('play', () => {
             const audio = audioRef.current
             if (!audio) return

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -467,13 +467,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         pinnedDurRef.current = realDur
         savedSrcBeforeSilenceRef.current = audio.src
         sessionKeepAliveRef.current = true
-        // Fire a real 'pause' event + declare paused BEFORE swapping to the
-        // silent track. The lock-screen 'pause' MediaSession action handler
-        // works because iOS's own gesture commits the Now Playing widget to
-        // paused; mimic that for in-app pause by giving iOS a real pause
-        // signal on the audio element first.
-        audio.pause()
-        pinLockScreenPosition(realPos, realDur)
         audio.src = SILENT_LOOP_SRC
         audio.loop = true
         audio.load()
@@ -484,6 +477,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             audio.pause()
         })
         setIsPlaying(false)
+        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
@@ -840,8 +834,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             pinnedDurRef.current = realDur
             savedSrcBeforeSilenceRef.current = audio.src
             sessionKeepAliveRef.current = true
-            audio.pause()
-            pinLockScreenPosition(realPos, realDur)
             audio.src = SILENT_LOOP_SRC
             audio.loop = true
             audio.load()
@@ -851,6 +843,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                 audio.pause()
             })
             setIsPlaying(false)
+            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,76 +445,39 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
-    // Build & set MediaMetadata for the current song. Called when current
-    // changes, and again on resume to restore the Now Playing widget after
-    // an in-app pause cleared it.
-    function setMediaSessionMetadata(song: PlayableSong) {
-        if (!song.properties || !('mediaSession' in navigator)) return
-        const p = song.properties
-        const origin = typeof window !== 'undefined' ? window.location.origin : ''
-        const sizes = [128, 192, 256, 384, 512]
-        const artwork: { src: string; sizes: string; type: string }[] = []
-        for (const s of sizes) {
-            const url = songArtworkUrl(song.uuid, song.artwork_cached, p.artworkUrl100, s)
-            if (!url) continue
-            const absolute = url.startsWith('/') ? `${origin}${url}` : url
-            artwork.push({ src: absolute, sizes: `${s}x${s}`, type: 'image/jpeg' })
-        }
-        navigator.mediaSession.metadata = new MediaMetadata({
-            title: p.trackName,
-            artist: p.artistName,
-            album: p.collectionName,
-            artwork,
-        })
-    }
-
-    // In-app pause clears the iOS Now Playing widget. Setting both metadata
-    // and playbackState lets iOS hide the widget entirely (or at least show
-    // a neutral state) instead of the misleading "playing" indicator that
-    // sticks when the audio element is paused but iOS hasn't refreshed.
-    function clearMediaSessionForInAppPause() {
-        if (!('mediaSession' in navigator)) return
-        navigator.mediaSession.metadata = null
-        navigator.mediaSession.playbackState = 'none'
-        try { navigator.mediaSession.setPositionState() } catch {}
-    }
-
-    // In-app pause is a clean audio.pause(). No silent-loop keep-alive here:
-    // iOS Now Playing reads element.paused = true and shows "paused" in sync
-    // with our UI. The lock-screen 'pause' MediaSession action handler still
-    // does the silent-loop trick — iOS commits its widget to paused on the
-    // user's gesture before our handler runs, so the widget shows paused there
-    // too. See cboin1996/songbirdweb#16 for the iOS quirk.
-    //
-    // Trade-off: after ~10s in-app paused + locked, iOS releases the audio
-    // session and lock-screen play stops responding. User unlocks and resumes
-    // in-app to recover.
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
+        // Already in silent-loop pause — nothing to do.
         if (sessionKeepAliveRef.current) {
-            // Came from lock-screen pause (silent loop running). Tear it down
-            // and hard-pause at the pinned position, so we end up in a clean
-            // paused state regardless of which path triggered the in-app pause.
-            const realSrc = savedSrcBeforeSilenceRef.current
-            const realPos = pinnedPosRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            if (realSrc) {
-                audio.src = realSrc
-                pendingPosition.current = realPos
-                shouldPlayRef.current = false
-                audio.load()
-            }
             setIsPlaying(false)
-            clearMediaSessionForInAppPause()
             return
         }
-        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
-        audio.pause()
+        // No real source loaded yet — fall back to a hard pause.
+        if (!audio.src || audio.paused) {
+            audio.pause()
+            setIsPlaying(false)
+            return
+        }
+        const realPos = audio.currentTime
+        const realDur = audio.duration
+        savePosition(current, realPos)
+        pendingPosition.current = realPos
+        pinnedPosRef.current = realPos
+        pinnedDurRef.current = realDur
+        savedSrcBeforeSilenceRef.current = audio.src
+        sessionKeepAliveRef.current = true
+        audio.src = SILENT_LOOP_SRC
+        audio.loop = true
+        audio.load()
+        audio.play().catch(() => {
+            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
+            sessionKeepAliveRef.current = false
+            audio.loop = false
+            audio.pause()
+        })
         setIsPlaying(false)
-        clearMediaSessionForInAppPause()
+        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
@@ -534,9 +497,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             unpinLockScreenPosition()
             return
         }
-        // Restore Now Playing widget after an in-app pause cleared it.
-        if (current) setMediaSessionMetadata(current)
-        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'playing'
         setIsPlaying(true)
         audio.play().catch(() => {})
     }
@@ -813,7 +773,27 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
 
     useEffect(() => {
         if (!current?.properties || !('mediaSession' in navigator)) return
-        setMediaSessionMetadata(current)
+        const p = current.properties
+        // iOS lock screen prefers several sizes; provide both small and large so the OS picks what fits.
+        // Use the absolute origin for cached artwork URLs since Media Session needs fully-qualified URLs.
+        const origin = typeof window !== 'undefined' ? window.location.origin : ''
+        const buildArtwork = (): { src: string; sizes: string; type: string }[] => {
+            const sizes = [128, 192, 256, 384, 512]
+            const out: { src: string; sizes: string; type: string }[] = []
+            for (const s of sizes) {
+                const url = songArtworkUrl(current.uuid, current.artwork_cached, p.artworkUrl100, s)
+                if (!url) continue
+                const absolute = url.startsWith('/') ? `${origin}${url}` : url
+                out.push({ src: absolute, sizes: `${s}x${s}`, type: 'image/jpeg' })
+            }
+            return out
+        }
+        navigator.mediaSession.metadata = new MediaMetadata({
+            title: p.trackName,
+            artist: p.artistName,
+            album: p.collectionName,
+            artwork: buildArtwork(),
+        })
         navigator.mediaSession.setActionHandler('play', () => {
             const audio = audioRef.current
             if (!audio) return

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -467,6 +467,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         pinnedDurRef.current = realDur
         savedSrcBeforeSilenceRef.current = audio.src
         sessionKeepAliveRef.current = true
+        // Declare paused to MediaSession BEFORE starting the silent loop so iOS
+        // sees the paused state when the audio session activates, instead of
+        // snapshotting "playing" off the silent-loop play event.
+        pinLockScreenPosition(realPos, realDur)
         audio.src = SILENT_LOOP_SRC
         audio.loop = true
         audio.load()
@@ -477,7 +481,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             audio.pause()
         })
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
@@ -834,6 +837,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             pinnedDurRef.current = realDur
             savedSrcBeforeSilenceRef.current = audio.src
             sessionKeepAliveRef.current = true
+            pinLockScreenPosition(realPos, realDur)
             audio.src = SILENT_LOOP_SRC
             audio.loop = true
             audio.load()
@@ -843,7 +847,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                 audio.pause()
             })
             setIsPlaying(false)
-            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,39 +445,41 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
+    // In-app pause: clean audio.pause(). No silent loop — we want the iOS Now
+    // Playing widget to show "paused" in sync with our UI. Trade-off: after ~10s
+    // backgrounded, iOS releases the audio session and the lock-screen play
+    // button goes unresponsive (user must unlock and tap play in the app to
+    // resume). The silent-loop keep-alive is preserved on the lock-screen
+    // 'pause' MediaSession action handler, where iOS's own gesture commits the
+    // widget to "paused" before we run.
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
-        // Already in silent-loop pause — nothing to do.
         if (sessionKeepAliveRef.current) {
-            setIsPlaying(false)
-            return
-        }
-        // No real source loaded yet — fall back to a hard pause.
-        if (!audio.src || audio.paused) {
-            audio.pause()
-            setIsPlaying(false)
-            return
-        }
-        const realPos = audio.currentTime
-        const realDur = audio.duration
-        savePosition(current, realPos)
-        pendingPosition.current = realPos
-        pinnedPosRef.current = realPos
-        pinnedDurRef.current = realDur
-        savedSrcBeforeSilenceRef.current = audio.src
-        sessionKeepAliveRef.current = true
-        audio.src = SILENT_LOOP_SRC
-        audio.loop = true
-        audio.load()
-        audio.play().catch(() => {
-            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
+            // Tear down the silent loop and hard-pause at the pinned position.
+            // Reaches here when the user pressed pause-on-lock-screen (silent
+            // loop running) and then opens the app and presses pause in-UI.
+            const realSrc = savedSrcBeforeSilenceRef.current
+            const realPos = pinnedPosRef.current
             sessionKeepAliveRef.current = false
+            savedSrcBeforeSilenceRef.current = null
             audio.loop = false
-            audio.pause()
-        })
+            if (realSrc) {
+                audio.src = realSrc
+                pendingPosition.current = realPos
+                shouldPlayRef.current = false
+                audio.load()
+            }
+            setIsPlaying(false)
+            if ('mediaSession' in navigator) {
+                navigator.mediaSession.playbackState = 'paused'
+                try { navigator.mediaSession.setPositionState() } catch {}
+            }
+            return
+        }
+        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
+        audio.pause()
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -445,39 +445,45 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         try { navigator.mediaSession.setPositionState() } catch {}
     }
 
+    // In-app pause is a clean audio.pause(). No silent-loop keep-alive here:
+    // iOS Now Playing reads element.paused = true and shows "paused" in sync
+    // with our UI. The lock-screen 'pause' MediaSession action handler still
+    // does the silent-loop trick — iOS commits its widget to paused on the
+    // user's gesture before our handler runs, so the widget shows paused there
+    // too. See cboin1996/songbirdweb#16 for the iOS quirk.
+    //
+    // Trade-off: after ~10s in-app paused + locked, iOS releases the audio
+    // session and lock-screen play stops responding. User unlocks and resumes
+    // in-app to recover.
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
-        // Already in silent-loop pause — nothing to do.
         if (sessionKeepAliveRef.current) {
-            setIsPlaying(false)
-            return
-        }
-        // No real source loaded yet — fall back to a hard pause.
-        if (!audio.src || audio.paused) {
-            audio.pause()
-            setIsPlaying(false)
-            return
-        }
-        const realPos = audio.currentTime
-        const realDur = audio.duration
-        savePosition(current, realPos)
-        pendingPosition.current = realPos
-        pinnedPosRef.current = realPos
-        pinnedDurRef.current = realDur
-        savedSrcBeforeSilenceRef.current = audio.src
-        sessionKeepAliveRef.current = true
-        audio.src = SILENT_LOOP_SRC
-        audio.loop = true
-        audio.load()
-        audio.play().catch(() => {
-            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
+            // Came from lock-screen pause (silent loop running). Tear it down
+            // and hard-pause at the pinned position, so we end up in a clean
+            // paused state regardless of which path triggered the in-app pause.
+            const realSrc = savedSrcBeforeSilenceRef.current
+            const realPos = pinnedPosRef.current
             sessionKeepAliveRef.current = false
+            savedSrcBeforeSilenceRef.current = null
             audio.loop = false
-            audio.pause()
-        })
+            if (realSrc) {
+                audio.src = realSrc
+                pendingPosition.current = realPos
+                shouldPlayRef.current = false
+                audio.load()
+            }
+            setIsPlaying(false)
+            if ('mediaSession' in navigator) {
+                navigator.mediaSession.playbackState = 'paused'
+                try { navigator.mediaSession.setPositionState() } catch {}
+            }
+            return
+        }
+        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
+        audio.pause()
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
+        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused'
     }
 
     function resume() {

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -28,6 +28,12 @@ function contextFromId(id: string | null): PlayContext | null {
 export type RepeatMode = 'off' | 'one' | 'all'
 export type PlayContext = { label: string; href: string; id: string }
 
+// iOS Safari releases the audio session ~10s after pausing in background, which
+// kills the lock-screen play action and forces the user to re-open Safari.
+// Looping a tiny silent track while "paused" keeps the session warm so lock-screen
+// controls stay responsive. Trade-off: a few % battery while paused.
+const SILENT_LOOP_SRC = '/silence.mp3'
+
 function seededShuffle(arr: number[], seed: number): number[] {
     // Mulberry32 PRNG — deterministic, fast, good distribution
     let s = seed >>> 0
@@ -211,11 +217,16 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     const [manualNextIds, setManualNextIds] = useState<Set<string>>(new Set())
     const shuffleSeedRef = useRef<number | null>(null)
     const playContextRef = useRef<PlayContext | null>(null)
-    // AudioContext + silent oscillator: keeps the iOS audio session warm while
-    // the <audio> element is genuinely paused, so the lock-screen play button
-    // stays responsive without making iOS Now Playing show "playing".
-    const audioContextRef = useRef<AudioContext | null>(null)
-    const oscillatorRef = useRef<OscillatorNode | null>(null)
+    // True while the audio element is looping SILENT_LOOP_SRC to preserve the
+    // iOS audio session during a logical pause. Listeners use this ref to skip
+    // UI side-effects (timeupdate, isPlaying flips) caused by the silent track.
+    const sessionKeepAliveRef = useRef(false)
+    const savedSrcBeforeSilenceRef = useRef<string | null>(null)
+    // Captured at pause time, re-asserted to MediaSession on each silent-loop
+    // tick so iOS doesn't fall back to reading audio.currentTime (which is the
+    // silent file's ~0). Cleared on resume.
+    const pinnedPosRef = useRef(0)
+    const pinnedDurRef = useRef(0)
 
     const showToast = useCallback((msg: string, error?: boolean) => {
         if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
@@ -242,7 +253,11 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     async function loadSong(song: PlayableSong, fromStart = false) {
         const audio = audioRef.current
         if (!audio) return
-        stopAudioSessionKeepAlive()
+        if (sessionKeepAliveRef.current) {
+            sessionKeepAliveRef.current = false
+            audio.loop = false
+            savedSrcBeforeSilenceRef.current = null
+        }
         const gen = ++loadGenRef.current
         pendingPosition.current = fromStart ? 0 : (song.last_position ?? 0)
         if (blobUrlRef.current) {
@@ -402,51 +417,86 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         scheduleSave()
     }
 
-    // Web Audio API session keep-alive — silent oscillator on an AudioContext
-    // keeps the iOS AVAudioSession warm while the <audio> element is genuinely
-    // paused. Lets iOS Now Playing read element.paused = true (widget shows
-    // "paused", in sync with our UI) while lock-screen play stays responsive.
-    function startAudioSessionKeepAlive() {
-        if (oscillatorRef.current) return
+    // Tell the OS lock-screen / control center to display this static position +
+    // the song's real duration while the silent loop runs the actual <audio>
+    // element. Without this, iOS reads audio.currentTime / audio.duration off the
+    // 1s silent file and shows 0:00 / 0:01.
+    //
+    // Per the W3C MediaSession spec, setPositionState requires playbackRate != 0
+    // (a zero rate throws TypeError). When playbackState is 'paused', iOS treats
+    // the position as static rather than extrapolating, so playbackRate=1 is just
+    // a placeholder.
+    function pinLockScreenPosition(position: number, duration: number) {
+        if (!('mediaSession' in navigator)) return
+        navigator.mediaSession.playbackState = 'paused'
+        if (!isFinite(duration) || duration <= 0 || !isFinite(position) || position < 0) return
         try {
-            const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
-            if (!Ctor) return
-            const ctx = audioContextRef.current ?? new Ctor()
-            if (ctx.state === 'suspended') ctx.resume().catch(() => {})
-            const osc = ctx.createOscillator()
-            const gain = ctx.createGain()
-            gain.gain.value = 0
-            osc.connect(gain)
-            gain.connect(ctx.destination)
-            osc.start()
-            audioContextRef.current = ctx
-            oscillatorRef.current = osc
+            navigator.mediaSession.setPositionState({
+                duration,
+                position: Math.min(position, duration),
+                playbackRate: 1,
+            })
         } catch {}
     }
 
-    function stopAudioSessionKeepAlive() {
-        try {
-            oscillatorRef.current?.stop()
-            oscillatorRef.current?.disconnect()
-        } catch {}
-        oscillatorRef.current = null
+    function unpinLockScreenPosition() {
+        if (!('mediaSession' in navigator)) return
+        navigator.mediaSession.playbackState = 'playing'
+        try { navigator.mediaSession.setPositionState() } catch {}
     }
 
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
-        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
-        audio.pause()
+        // Already in silent-loop pause — nothing to do.
+        if (sessionKeepAliveRef.current) {
+            setIsPlaying(false)
+            return
+        }
+        // No real source loaded yet — fall back to a hard pause.
+        if (!audio.src || audio.paused) {
+            audio.pause()
+            setIsPlaying(false)
+            return
+        }
+        const realPos = audio.currentTime
+        const realDur = audio.duration
+        savePosition(current, realPos)
+        pendingPosition.current = realPos
+        pinnedPosRef.current = realPos
+        pinnedDurRef.current = realDur
+        savedSrcBeforeSilenceRef.current = audio.src
+        sessionKeepAliveRef.current = true
+        audio.src = SILENT_LOOP_SRC
+        audio.loop = true
+        audio.load()
+        audio.play().catch(() => {
+            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
+            sessionKeepAliveRef.current = false
+            audio.loop = false
+            audio.pause()
+        })
         setIsPlaying(false)
-        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused'
-        startAudioSessionKeepAlive()
+        pinLockScreenPosition(realPos, realDur)
     }
 
     function resume() {
         const audio = audioRef.current
         if (!audio) return
-        stopAudioSessionKeepAlive()
-        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'playing'
+        if (sessionKeepAliveRef.current) {
+            const realSrc = savedSrcBeforeSilenceRef.current
+            sessionKeepAliveRef.current = false
+            savedSrcBeforeSilenceRef.current = null
+            audio.loop = false
+            if (realSrc) {
+                audio.src = realSrc
+                shouldPlayRef.current = true
+                audio.load()
+            }
+            setIsPlaying(true)
+            unpinLockScreenPosition()
+            return
+        }
         setIsPlaying(true)
         audio.play().catch(() => {})
     }
@@ -597,6 +647,15 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         const audio = audioRef.current
         if (!audio) return
         function onCanPlay() {
+            // Silent loop is just keeping the audio session alive — start it without
+            // applying pendingPosition (which holds the *real* song position for resume).
+            if (sessionKeepAliveRef.current) {
+                if (shouldPlayRef.current) {
+                    shouldPlayRef.current = false
+                    audio!.play().catch(() => {})
+                }
+                return
+            }
             setIsBuffering(false)
             if (pendingPosition.current > 0) {
                 audio!.currentTime = pendingPosition.current
@@ -608,30 +667,50 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             }
         }
         function onPlay() {
+            if (sessionKeepAliveRef.current) return
             setIsPlaying(true); setIsBuffering(false); autoplayActivatedRef.current = true
-            stopAudioSessionKeepAlive()
         }
         function onPause() {
+            if (sessionKeepAliveRef.current) return
             setIsPlaying(false); setIsBuffering(false)
         }
         function onLoadStart() {
+            if (sessionKeepAliveRef.current) return
             setIsBuffering(true); setBuffered(0)
         }
         function onWaiting() {
+            if (sessionKeepAliveRef.current) return
             setIsBuffering(true)
         }
         function onPlaying() {
+            if (sessionKeepAliveRef.current) return
             setIsBuffering(false)
         }
         function onTimeUpdate() {
+            if (sessionKeepAliveRef.current) {
+                // Re-assert the pinned position on every silent-loop tick so iOS
+                // can't fall back to reading audio.currentTime (=0 on the silent
+                // file). Without this the lock-screen playhead drifts to 0:00.
+                pinLockScreenPosition(pinnedPosRef.current, pinnedDurRef.current)
+                return
+            }
             setCurrentTime(audio!.currentTime)
             if (audio!.buffered.length > 0) setBuffered(audio!.buffered.end(audio!.buffered.length - 1))
         }
         function onDurationChange() {
+            if (sessionKeepAliveRef.current) return
             setDuration(audio!.duration)
         }
         function onError() {
             if (!audio!.src) return
+            // Silent loop failed — drop keep-alive instead of looping the error.
+            if (sessionKeepAliveRef.current) {
+                sessionKeepAliveRef.current = false
+                savedSrcBeforeSilenceRef.current = null
+                audio!.loop = false
+                audio!.pause()
+                return
+            }
             pendingPosition.current = audio!.currentTime || 0
             shouldPlayRef.current = true
             audio!.load()
@@ -718,19 +797,53 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         navigator.mediaSession.setActionHandler('play', () => {
             const audio = audioRef.current
             if (!audio) return
-            stopAudioSessionKeepAlive()
-            navigator.mediaSession.playbackState = 'playing'
+            if (sessionKeepAliveRef.current) {
+                const realSrc = savedSrcBeforeSilenceRef.current
+                sessionKeepAliveRef.current = false
+                savedSrcBeforeSilenceRef.current = null
+                audio.loop = false
+                if (realSrc) {
+                    audio.src = realSrc
+                    shouldPlayRef.current = true
+                    audio.load()
+                }
+                setIsPlaying(true)
+                unpinLockScreenPosition()
+                return
+            }
             setIsPlaying(true)
             audio.play().catch(() => {})
         })
         navigator.mediaSession.setActionHandler('pause', () => {
             const audio = audioRef.current
             if (!audio) return
-            if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
-            audio.pause()
+            if (sessionKeepAliveRef.current) {
+                setIsPlaying(false)
+                return
+            }
+            if (!audio.src || audio.paused) {
+                audio.pause()
+                setIsPlaying(false)
+                return
+            }
+            const realPos = audio.currentTime
+            const realDur = audio.duration
+            savePosition(current, realPos)
+            pendingPosition.current = realPos
+            pinnedPosRef.current = realPos
+            pinnedDurRef.current = realDur
+            savedSrcBeforeSilenceRef.current = audio.src
+            sessionKeepAliveRef.current = true
+            audio.src = SILENT_LOOP_SRC
+            audio.loop = true
+            audio.load()
+            audio.play().catch(() => {
+                sessionKeepAliveRef.current = false
+                audio.loop = false
+                audio.pause()
+            })
             setIsPlaying(false)
-            navigator.mediaSession.playbackState = 'paused'
-            startAudioSessionKeepAlive()
+            pinLockScreenPosition(realPos, realDur)
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)
@@ -744,7 +857,10 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             if (!audio || !current) return
             if (e.code === 'Space') {
                 e.preventDefault()
-                if (audio.paused) resume()
+                // Route through pause/resume so the silent-loop keep-alive stays
+                // consistent. audio.paused lies during silent-loop pause (the loop
+                // is playing) — sessionKeepAliveRef is the source of truth.
+                if (sessionKeepAliveRef.current || audio.paused) resume()
                 else pause()
             } else if (e.code === 'ArrowLeft') {
                 e.preventDefault()
@@ -761,33 +877,45 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [current, skipPrev, skipNext])
 
-    // iOS sometimes forgets the previoustrack/nexttrack action handlers after
-    // backgrounded suspension, falling back to ±10s seek markers on the lock-
-    // screen. Re-bind on every re-foreground. Also ensures the AudioContext
-    // keep-alive resumes if iOS suspended it during the background period.
+    // iOS suspends backgrounded tabs after ~20s, killing the silent loop that
+    // keeps the audio session warm. When the user reopens the app (especially
+    // in full-screen mode where there's no pull-to-refresh), the audio element
+    // can be in a stuck buffering state with no path back. Detect that on
+    // visibilitychange and reset the UI to "ready to play" so a user tap
+    // initiates a fresh load instead of staring at a spinner.
     useEffect(() => {
         function onVisible() {
             if (document.hidden) return
+
+            // iOS sometimes forgets the previoustrack/nexttrack handlers after
+            // backgrounded suspension, falling back to ±10s seek markers on the
+            // lock-screen. Re-bind on every re-foreground.
             if ('mediaSession' in navigator) {
                 navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
                 navigator.mediaSession.setActionHandler('nexttrack', skipNext)
             }
-            if (oscillatorRef.current && audioContextRef.current?.state === 'suspended') {
-                audioContextRef.current.resume().catch(() => {})
+
+            const audio = audioRef.current
+            if (!audio) return
+            if (!sessionKeepAliveRef.current) return
+            if (!audio.paused) return  // silent loop still alive — nothing to do
+
+            const realSrc = savedSrcBeforeSilenceRef.current
+            sessionKeepAliveRef.current = false
+            savedSrcBeforeSilenceRef.current = null
+            audio.loop = false
+            shouldPlayRef.current = false
+            if (realSrc) {
+                audio.src = realSrc
+                audio.load()
             }
+            setIsPlaying(false)
+            setIsBuffering(false)
+            unpinLockScreenPosition()
         }
         document.addEventListener('visibilitychange', onVisible)
         return () => document.removeEventListener('visibilitychange', onVisible)
     }, [skipPrev, skipNext])
-
-    useEffect(() => {
-        return () => {
-            stopAudioSessionKeepAlive()
-            audioContextRef.current?.close().catch(() => {})
-            audioContextRef.current = null
-        }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [])
 
     useEffect(() => {
         Promise.all([fetchPlayerState(), fetchLibrarySongs()]).then(async ([serverState, libSongs]) => {

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -28,12 +28,6 @@ function contextFromId(id: string | null): PlayContext | null {
 export type RepeatMode = 'off' | 'one' | 'all'
 export type PlayContext = { label: string; href: string; id: string }
 
-// iOS Safari releases the audio session ~10s after pausing in background, which
-// kills the lock-screen play action and forces the user to re-open Safari.
-// Looping a tiny silent track while "paused" keeps the session warm so lock-screen
-// controls stay responsive. Trade-off: a few % battery while paused.
-const SILENT_LOOP_SRC = '/silence.mp3'
-
 function seededShuffle(arr: number[], seed: number): number[] {
     // Mulberry32 PRNG — deterministic, fast, good distribution
     let s = seed >>> 0
@@ -217,16 +211,11 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     const [manualNextIds, setManualNextIds] = useState<Set<string>>(new Set())
     const shuffleSeedRef = useRef<number | null>(null)
     const playContextRef = useRef<PlayContext | null>(null)
-    // True while the audio element is looping SILENT_LOOP_SRC to preserve the
-    // iOS audio session during a logical pause. Listeners use this ref to skip
-    // UI side-effects (timeupdate, isPlaying flips) caused by the silent track.
-    const sessionKeepAliveRef = useRef(false)
-    const savedSrcBeforeSilenceRef = useRef<string | null>(null)
-    // Captured at pause time, re-asserted to MediaSession on each silent-loop
-    // tick so iOS doesn't fall back to reading audio.currentTime (which is the
-    // silent file's ~0). Cleared on resume.
-    const pinnedPosRef = useRef(0)
-    const pinnedDurRef = useRef(0)
+    // AudioContext + silent oscillator: keeps the iOS audio session warm while
+    // the <audio> element is genuinely paused, so the lock-screen play button
+    // stays responsive without making iOS Now Playing show "playing".
+    const audioContextRef = useRef<AudioContext | null>(null)
+    const oscillatorRef = useRef<OscillatorNode | null>(null)
 
     const showToast = useCallback((msg: string, error?: boolean) => {
         if (toastTimerRef.current) clearTimeout(toastTimerRef.current)
@@ -253,11 +242,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     async function loadSong(song: PlayableSong, fromStart = false) {
         const audio = audioRef.current
         if (!audio) return
-        if (sessionKeepAliveRef.current) {
-            sessionKeepAliveRef.current = false
-            audio.loop = false
-            savedSrcBeforeSilenceRef.current = null
-        }
+        stopAudioSessionKeepAlive()
         const gen = ++loadGenRef.current
         pendingPosition.current = fromStart ? 0 : (song.last_position ?? 0)
         if (blobUrlRef.current) {
@@ -417,86 +402,51 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         scheduleSave()
     }
 
-    // Tell the OS lock-screen / control center to display this static position +
-    // the song's real duration while the silent loop runs the actual <audio>
-    // element. Without this, iOS reads audio.currentTime / audio.duration off the
-    // 1s silent file and shows 0:00 / 0:01.
-    //
-    // Per the W3C MediaSession spec, setPositionState requires playbackRate != 0
-    // (a zero rate throws TypeError). When playbackState is 'paused', iOS treats
-    // the position as static rather than extrapolating, so playbackRate=1 is just
-    // a placeholder.
-    function pinLockScreenPosition(position: number, duration: number) {
-        if (!('mediaSession' in navigator)) return
-        navigator.mediaSession.playbackState = 'paused'
-        if (!isFinite(duration) || duration <= 0 || !isFinite(position) || position < 0) return
+    // Web Audio API session keep-alive — silent oscillator on an AudioContext
+    // keeps the iOS AVAudioSession warm while the <audio> element is genuinely
+    // paused. Lets iOS Now Playing read element.paused = true (widget shows
+    // "paused", in sync with our UI) while lock-screen play stays responsive.
+    function startAudioSessionKeepAlive() {
+        if (oscillatorRef.current) return
         try {
-            navigator.mediaSession.setPositionState({
-                duration,
-                position: Math.min(position, duration),
-                playbackRate: 1,
-            })
+            const Ctor = window.AudioContext || (window as unknown as { webkitAudioContext: typeof AudioContext }).webkitAudioContext
+            if (!Ctor) return
+            const ctx = audioContextRef.current ?? new Ctor()
+            if (ctx.state === 'suspended') ctx.resume().catch(() => {})
+            const osc = ctx.createOscillator()
+            const gain = ctx.createGain()
+            gain.gain.value = 0
+            osc.connect(gain)
+            gain.connect(ctx.destination)
+            osc.start()
+            audioContextRef.current = ctx
+            oscillatorRef.current = osc
         } catch {}
     }
 
-    function unpinLockScreenPosition() {
-        if (!('mediaSession' in navigator)) return
-        navigator.mediaSession.playbackState = 'playing'
-        try { navigator.mediaSession.setPositionState() } catch {}
+    function stopAudioSessionKeepAlive() {
+        try {
+            oscillatorRef.current?.stop()
+            oscillatorRef.current?.disconnect()
+        } catch {}
+        oscillatorRef.current = null
     }
 
     function pause() {
         const audio = audioRef.current
         if (!audio || !current) return
-        // Already in silent-loop pause — nothing to do.
-        if (sessionKeepAliveRef.current) {
-            setIsPlaying(false)
-            return
-        }
-        // No real source loaded yet — fall back to a hard pause.
-        if (!audio.src || audio.paused) {
-            audio.pause()
-            setIsPlaying(false)
-            return
-        }
-        const realPos = audio.currentTime
-        const realDur = audio.duration
-        savePosition(current, realPos)
-        pendingPosition.current = realPos
-        pinnedPosRef.current = realPos
-        pinnedDurRef.current = realDur
-        savedSrcBeforeSilenceRef.current = audio.src
-        sessionKeepAliveRef.current = true
-        audio.src = SILENT_LOOP_SRC
-        audio.loop = true
-        audio.load()
-        audio.play().catch(() => {
-            // Silent loop failed to start — drop the keep-alive and fall back to a hard pause.
-            sessionKeepAliveRef.current = false
-            audio.loop = false
-            audio.pause()
-        })
+        if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
+        audio.pause()
         setIsPlaying(false)
-        pinLockScreenPosition(realPos, realDur)
+        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'paused'
+        startAudioSessionKeepAlive()
     }
 
     function resume() {
         const audio = audioRef.current
         if (!audio) return
-        if (sessionKeepAliveRef.current) {
-            const realSrc = savedSrcBeforeSilenceRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            if (realSrc) {
-                audio.src = realSrc
-                shouldPlayRef.current = true
-                audio.load()
-            }
-            setIsPlaying(true)
-            unpinLockScreenPosition()
-            return
-        }
+        stopAudioSessionKeepAlive()
+        if ('mediaSession' in navigator) navigator.mediaSession.playbackState = 'playing'
         setIsPlaying(true)
         audio.play().catch(() => {})
     }
@@ -647,15 +597,6 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         const audio = audioRef.current
         if (!audio) return
         function onCanPlay() {
-            // Silent loop is just keeping the audio session alive — start it without
-            // applying pendingPosition (which holds the *real* song position for resume).
-            if (sessionKeepAliveRef.current) {
-                if (shouldPlayRef.current) {
-                    shouldPlayRef.current = false
-                    audio!.play().catch(() => {})
-                }
-                return
-            }
             setIsBuffering(false)
             if (pendingPosition.current > 0) {
                 audio!.currentTime = pendingPosition.current
@@ -667,50 +608,30 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             }
         }
         function onPlay() {
-            if (sessionKeepAliveRef.current) return
             setIsPlaying(true); setIsBuffering(false); autoplayActivatedRef.current = true
+            stopAudioSessionKeepAlive()
         }
         function onPause() {
-            if (sessionKeepAliveRef.current) return
             setIsPlaying(false); setIsBuffering(false)
         }
         function onLoadStart() {
-            if (sessionKeepAliveRef.current) return
             setIsBuffering(true); setBuffered(0)
         }
         function onWaiting() {
-            if (sessionKeepAliveRef.current) return
             setIsBuffering(true)
         }
         function onPlaying() {
-            if (sessionKeepAliveRef.current) return
             setIsBuffering(false)
         }
         function onTimeUpdate() {
-            if (sessionKeepAliveRef.current) {
-                // Re-assert the pinned position on every silent-loop tick so iOS
-                // can't fall back to reading audio.currentTime (=0 on the silent
-                // file). Without this the lock-screen playhead drifts to 0:00.
-                pinLockScreenPosition(pinnedPosRef.current, pinnedDurRef.current)
-                return
-            }
             setCurrentTime(audio!.currentTime)
             if (audio!.buffered.length > 0) setBuffered(audio!.buffered.end(audio!.buffered.length - 1))
         }
         function onDurationChange() {
-            if (sessionKeepAliveRef.current) return
             setDuration(audio!.duration)
         }
         function onError() {
             if (!audio!.src) return
-            // Silent loop failed — drop keep-alive instead of looping the error.
-            if (sessionKeepAliveRef.current) {
-                sessionKeepAliveRef.current = false
-                savedSrcBeforeSilenceRef.current = null
-                audio!.loop = false
-                audio!.pause()
-                return
-            }
             pendingPosition.current = audio!.currentTime || 0
             shouldPlayRef.current = true
             audio!.load()
@@ -797,53 +718,19 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
         navigator.mediaSession.setActionHandler('play', () => {
             const audio = audioRef.current
             if (!audio) return
-            if (sessionKeepAliveRef.current) {
-                const realSrc = savedSrcBeforeSilenceRef.current
-                sessionKeepAliveRef.current = false
-                savedSrcBeforeSilenceRef.current = null
-                audio.loop = false
-                if (realSrc) {
-                    audio.src = realSrc
-                    shouldPlayRef.current = true
-                    audio.load()
-                }
-                setIsPlaying(true)
-                unpinLockScreenPosition()
-                return
-            }
+            stopAudioSessionKeepAlive()
+            navigator.mediaSession.playbackState = 'playing'
             setIsPlaying(true)
             audio.play().catch(() => {})
         })
         navigator.mediaSession.setActionHandler('pause', () => {
             const audio = audioRef.current
             if (!audio) return
-            if (sessionKeepAliveRef.current) {
-                setIsPlaying(false)
-                return
-            }
-            if (!audio.src || audio.paused) {
-                audio.pause()
-                setIsPlaying(false)
-                return
-            }
-            const realPos = audio.currentTime
-            const realDur = audio.duration
-            savePosition(current, realPos)
-            pendingPosition.current = realPos
-            pinnedPosRef.current = realPos
-            pinnedDurRef.current = realDur
-            savedSrcBeforeSilenceRef.current = audio.src
-            sessionKeepAliveRef.current = true
-            audio.src = SILENT_LOOP_SRC
-            audio.loop = true
-            audio.load()
-            audio.play().catch(() => {
-                sessionKeepAliveRef.current = false
-                audio.loop = false
-                audio.pause()
-            })
+            if (audio.src && !audio.paused) savePosition(current, audio.currentTime)
+            audio.pause()
             setIsPlaying(false)
-            pinLockScreenPosition(realPos, realDur)
+            navigator.mediaSession.playbackState = 'paused'
+            startAudioSessionKeepAlive()
         })
         navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
         navigator.mediaSession.setActionHandler('nexttrack', skipNext)
@@ -857,10 +744,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
             if (!audio || !current) return
             if (e.code === 'Space') {
                 e.preventDefault()
-                // Route through pause/resume so the silent-loop keep-alive stays
-                // consistent. audio.paused lies during silent-loop pause (the loop
-                // is playing) — sessionKeepAliveRef is the source of truth.
-                if (sessionKeepAliveRef.current || audio.paused) resume()
+                if (audio.paused) resume()
                 else pause()
             } else if (e.code === 'ArrowLeft') {
                 e.preventDefault()
@@ -877,45 +761,33 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [current, skipPrev, skipNext])
 
-    // iOS suspends backgrounded tabs after ~20s, killing the silent loop that
-    // keeps the audio session warm. When the user reopens the app (especially
-    // in full-screen mode where there's no pull-to-refresh), the audio element
-    // can be in a stuck buffering state with no path back. Detect that on
-    // visibilitychange and reset the UI to "ready to play" so a user tap
-    // initiates a fresh load instead of staring at a spinner.
+    // iOS sometimes forgets the previoustrack/nexttrack action handlers after
+    // backgrounded suspension, falling back to ±10s seek markers on the lock-
+    // screen. Re-bind on every re-foreground. Also ensures the AudioContext
+    // keep-alive resumes if iOS suspended it during the background period.
     useEffect(() => {
         function onVisible() {
             if (document.hidden) return
-
-            // iOS sometimes forgets the previoustrack/nexttrack handlers after
-            // backgrounded suspension, falling back to ±10s seek markers on the
-            // lock-screen. Re-bind on every re-foreground.
             if ('mediaSession' in navigator) {
                 navigator.mediaSession.setActionHandler('previoustrack', skipPrev)
                 navigator.mediaSession.setActionHandler('nexttrack', skipNext)
             }
-
-            const audio = audioRef.current
-            if (!audio) return
-            if (!sessionKeepAliveRef.current) return
-            if (!audio.paused) return  // silent loop still alive — nothing to do
-
-            const realSrc = savedSrcBeforeSilenceRef.current
-            sessionKeepAliveRef.current = false
-            savedSrcBeforeSilenceRef.current = null
-            audio.loop = false
-            shouldPlayRef.current = false
-            if (realSrc) {
-                audio.src = realSrc
-                audio.load()
+            if (oscillatorRef.current && audioContextRef.current?.state === 'suspended') {
+                audioContextRef.current.resume().catch(() => {})
             }
-            setIsPlaying(false)
-            setIsBuffering(false)
-            unpinLockScreenPosition()
         }
         document.addEventListener('visibilitychange', onVisible)
         return () => document.removeEventListener('visibilitychange', onVisible)
     }, [skipPrev, skipNext])
+
+    useEffect(() => {
+        return () => {
+            stopAudioSessionKeepAlive()
+            audioContextRef.current?.close().catch(() => {})
+            audioContextRef.current = null
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [])
 
     useEffect(() => {
         Promise.all([fetchPlayerState(), fetchLibrarySongs()]).then(async ([serverState, libSongs]) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.4.3",
+  "version": "0.4.4",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary

- In-app pause now does a clean `audio.pause()` while the page is visible, so iOS Now Playing widget (Dynamic Island, Control Center) syncs to **paused** instead of always showing "playing"
- Silent-loop iOS-audio-session keep-alive is now gated on `document.hidden` — fires only when the page goes hidden, preserving lock-screen play responsiveness
- Lock-screen pause/play gestures still go through main's single-element `audio.src` swap (preserves iOS gesture-priority widget commit)
- Residual gap: pause-in-app then lock-screen still shows the silent loop on the widget. Visibility transitions aren't user gestures, so iOS re-polls element state on the src swap. Verified spec-impossible on web — see [#16](https://github.com/cboin1996/songbirdweb/issues/16) for the full research log + experiment table

## Solved cases

| Flow | Widget state | Controls |
|---|---|---|
| In-app pause (UI open) | **paused** ✓ (was the original bug) | working |
| Play in app → lock → tap pause on widget | paused ✓ | working |
| Paused → tap pause → tap play on widget | paused → playing ✓ | working |
| Lock-screen play tap from any pause state | playing ✓ | resumes real audio |

## Test plan

- [x] In-app pause → Dynamic Island shows paused
- [x] In-app pause → Control Center widget shows paused
- [x] Lock-screen pause-while-playing → widget shows paused
- [x] Lock-screen play recovers audio from any paused state
- [x] No regression in: skip, scrubber, metadata, artwork
- [x] Tested on real iOS device (Safari)
- [ ] Known residual: pause-in-app → lock screen → widget shows silent loop (acceptable per #16, follow-up via FSM refactor + native iOS path)