### PR TITLE
fix: editor admin checkbox missing UserProvider

### DIFF
--- a/app/(authed)/songs/layout.tsx
+++ b/app/(authed)/songs/layout.tsx
@@ -1,0 +1,5 @@
+import AppLayout from "../../components/app-layout";
+
+export default function SongsLayout({ children }: { children: React.ReactNode }) {
+    return <AppLayout>{children}</AppLayout>
+}

--- a/app/components/editor-modal.tsx
+++ b/app/components/editor-modal.tsx
@@ -2693,6 +2693,12 @@ export default function EditorModal({
 
             {/* actions */}
             <div className="flex flex-col gap-2 pt-1">
+              {isAdmin && (
+                <label className="flex items-center gap-1.5 text-sm select-none cursor-pointer">
+                  <input data-testid="editor-overwrite-checkbox" type="checkbox" checked={publishAsOriginal} onChange={e => { setPublishAsOriginal(e.target.checked); setOverwrite(e.target.checked) }} className="accent-red-500" />
+                  <span className={publishAsOriginal ? 'text-red-400 font-medium' : 'text-gray-400'}>save as original</span>
+                </label>
+              )}
               <div className="flex items-center gap-2">
                 <button
                   onClick={handleSave}
@@ -2736,12 +2742,6 @@ export default function EditorModal({
                   </button>
                 )}
               </div>
-              {isAdmin && (
-                <label className="flex items-center gap-1.5 text-sm select-none cursor-pointer">
-                  <input data-testid="editor-overwrite-checkbox" type="checkbox" checked={publishAsOriginal} onChange={e => { setPublishAsOriginal(e.target.checked); setOverwrite(e.target.checked) }} className="accent-red-500" />
-                  <span className={publishAsOriginal ? 'text-red-400 font-medium' : 'text-gray-400'}>save as original</span>
-                </label>
-              )}
             </div>
 
             </div>{/* end edit-controls wrapper */}


### PR DESCRIPTION
## Summary
- The `songs/[id]/edit` page had no `AppLayout` wrapper, so `useUser()` returned the default context (`isAdmin: false`). Admin-only controls like the overwrite checkbox never rendered.
- Adds `songs/layout.tsx` wrapping in `AppLayout`
- Moves overwrite checkbox above Save to Library button for better visibility

## Test plan
- [x] Manual: logged in as admin, opened editor, checkbox visible
- [x] Manual: "save as original" overwrites in-place (verified in DB)
- [x] e2e: 247 passed, 3 failed (all pre-existing data/env issues, not regressions)