### PR TITLE
feat: download instant search, touch targets, settings flash fix

### DIFF
--- a/app/(authed)/download/layout.tsx
+++ b/app/(authed)/download/layout.tsx
@@ -10,11 +10,9 @@ export default async function Layout({ children }: { children: React.ReactNode }
         <UserProvider isAdmin={user?.role === 'admin'} username={user?.username ?? ''} userLoaded={user !== undefined}>
             <NavBar />
             <OfflineGuard feature="download">
-                <div className="sticky top-11 z-40 bg-[var(--background)]/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800 px-2">
-                    <Suspense>
-                        <Search />
-                    </Suspense>
-                </div>
+                <Suspense>
+                    <Search />
+                </Suspense>
                 <Suspense>
                     {children}
                 </Suspense>

--- a/app/(authed)/download/song/page.tsx
+++ b/app/(authed)/download/song/page.tsx
@@ -1,17 +1,9 @@
 'use client'
 import { useSearchParams } from "next/navigation"
 import { useQuery } from "@tanstack/react-query"
-import { fetchPropertiesFromItunes, fetchPropertiesFromIndex, DownloadedSong } from "../../../lib/data"
+import { fetchPropertiesFromItunes, DownloadedSong } from "../../../lib/data"
 import SongsSelector from "../../../components/songs"
 import QueryError from "../../../components/query-error"
-
-async function searchSongs(query: string, lookup: boolean, limit: number): Promise<DownloadedSong[]> {
-    const properties = await fetchPropertiesFromIndex(query)
-    if (properties === undefined) return []
-    const itunesProperties = await fetchPropertiesFromItunes(query, lookup, limit)
-    if (itunesProperties === undefined) return properties
-    return [...properties, ...itunesProperties]
-}
 
 export default function Page() {
     const searchParams = useSearchParams()
@@ -20,19 +12,20 @@ export default function Page() {
     const limit = Number(searchParams.get('limit')) || 10
 
     const { data: songs, error, refetch, isLoading } = useQuery({
-        queryKey: ['song-search', query, lookup, limit],
-        queryFn: () => searchSongs(query, lookup, limit),
+        queryKey: ['itunes-search', query, lookup, limit],
+        queryFn: () => fetchPropertiesFromItunes(query, lookup, limit),
         enabled: query !== '',
         retry: false,
     })
 
     if (!query) return null
-    if (isLoading) return <main className="p-4"><p className="text-gray-400 text-sm">searching…</p></main>
-    if (error) return <main className="p-4"><QueryError error={error} retry={refetch} context="search results" /></main>
+    if (isLoading) return <main className="p-4"><p className="text-gray-400 text-sm">searching iTunes…</p></main>
+    if (error) return <main className="p-4"><QueryError error={error} retry={refetch} context="iTunes search" /></main>
+    if (!songs || songs.length === 0) return <main className="p-4"><p className="text-gray-400 text-sm">no iTunes matches</p></main>
 
     return (
         <main>
-            <SongsSelector key={query} songs={songs ?? []} />
+            <SongsSelector songs={songs} />
         </main>
     )
 }

--- a/app/(authed)/download/song/page.tsx
+++ b/app/(authed)/download/song/page.tsx
@@ -20,7 +20,7 @@ export default function Page() {
 
     if (!query) return null
     if (isLoading) return <main className="p-4"><p className="text-gray-400 text-sm">searching iTunes…</p></main>
-    if (error) return <main className="p-4"><QueryError error={error} retry={refetch} context="iTunes search" /></main>
+    if (error) return <main className="p-4"><QueryError error={error} retry={refetch} context="search results" /></main>
     if (!songs || songs.length === 0) return <main className="p-4"><p className="text-gray-400 text-sm">no iTunes matches</p></main>
 
     return (

--- a/app/(authed)/library/edits-banner.tsx
+++ b/app/(authed)/library/edits-banner.tsx
@@ -98,7 +98,7 @@ export default function EditsBanner() {
                 <button
                   onClick={() => handleDelete(d.song_id)}
                   title="discard draft"
-                  className="shrink-0 text-gray-300 hover:text-red-400 dark:text-gray-600 dark:hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100"
+                  className="shrink-0 text-gray-300 hover:text-red-400 dark:text-gray-600 dark:hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 p-2 -m-1 touch-manipulation"
                 >
                   <FaTimes size={11} />
                 </button>

--- a/app/(authed)/library/playlists-view.tsx
+++ b/app/(authed)/library/playlists-view.tsx
@@ -207,14 +207,14 @@ export default function PlaylistsView({
                             const Icon = PLAYLIST_ICONS[k]
                             return (
                                 <button key={k} type="button" onClick={() => setRenameIcon(k)}
-                                    className={`p-1 rounded transition-colors ${renameIcon === k ? 'bg-sky-500 text-white' : 'text-gray-400 hover:text-sky-500'}`}>
+                                    className={`p-2 -m-0.5 rounded transition-colors touch-manipulation ${renameIcon === k ? 'bg-sky-500 text-white' : 'text-gray-400 hover:text-sky-500'}`}>
                                     <Icon size={11} />
                                 </button>
                             )
                         })}
                     </div>
                     <button type="submit" className="text-xs px-2 py-0.5 bg-sky-500 text-white rounded shrink-0">save</button>
-                    <button type="button" onClick={() => setRenaming(false)} className="text-gray-400 hover:text-gray-600 p-1">
+                    <button type="button" onClick={() => setRenaming(false)} className="text-gray-400 hover:text-gray-600 p-2 -m-1 touch-manipulation">
                         <FaTimes size={10} />
                     </button>
                 </form>
@@ -222,14 +222,14 @@ export default function PlaylistsView({
                 <>
                     <button
                         onClick={() => { setRenameValue(modalPlaylist.name); setRenameIcon(modalPlaylist.icon ?? 'music'); setRenaming(true) }}
-                        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1"
+                        className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-2 -m-1 touch-manipulation"
                         title="rename"
                     >
                         <FaPencilAlt size={11} />
                     </button>
                     <button
                         onClick={handleDelete}
-                        className="text-gray-400 hover:text-red-400 p-1"
+                        className="text-gray-400 hover:text-red-400 p-2 -m-1 touch-manipulation"
                         title="delete playlist"
                     >
                         <FaTrash size={11} />

--- a/app/(authed)/settings/page.tsx
+++ b/app/(authed)/settings/page.tsx
@@ -32,7 +32,7 @@ function PasswordField({ placeholder, value, onChange, inputRef }: {
             <button
                 type="button"
                 tabIndex={-1}
-                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+                className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600 p-2 -m-1 touch-manipulation"
                 onClick={() => setShow(p => !p)}
             >
                 {show ? <FaEyeSlash size={14} /> : <FaEye size={14} />}

--- a/app/(authed)/settings/page.tsx
+++ b/app/(authed)/settings/page.tsx
@@ -194,7 +194,7 @@ function CacheAudit() {
 }
 
 function AudioFormatSetting() {
-    const { settings, saveSettings } = useSettings()
+    const { settings, settingsLoaded, saveSettings } = useSettings()
     const [saving, setSaving] = useState(false)
 
     async function handleChange(format: AudioFormat) {
@@ -216,12 +216,14 @@ function AudioFormatSetting() {
                 {options.map(fmt => (
                     <button
                         key={fmt}
-                        disabled={saving}
+                        disabled={saving || !settingsLoaded}
                         onClick={() => handleChange(fmt)}
                         className={`flex-1 px-3 py-1.5 text-sm rounded-lg border transition-colors ${
-                            settings.audio_format === fmt
-                                ? 'bg-sky-500 text-white border-sky-500'
-                                : 'border-gray-200 dark:border-gray-700 hover:border-sky-500 hover:text-sky-500'
+                            !settingsLoaded
+                                ? 'border-gray-200 dark:border-gray-700 text-gray-400'
+                                : settings.audio_format === fmt
+                                    ? 'bg-sky-500 text-white border-sky-500'
+                                    : 'border-gray-200 dark:border-gray-700 hover:border-sky-500 hover:text-sky-500'
                         }`}
                     >
                         {fmt.toUpperCase()}

--- a/app/(authed)/songs/[id]/edit/page.tsx
+++ b/app/(authed)/songs/[id]/edit/page.tsx
@@ -32,7 +32,7 @@ export default function EditPage({ params }: { params: Promise<{ id: string }> }
             <div className="fixed inset-0 z-[60] bg-white dark:bg-gray-950 flex flex-col overflow-y-auto">
                 <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 shrink-0">
                     <div className="flex-1 min-w-0"><p className="font-medium text-base">editor</p></div>
-                    <button onClick={() => router.back()} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-1 ml-1 transition-colors">
+                    <button onClick={() => router.back()} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-2 -m-1 ml-1 transition-colors touch-manipulation">
                         <FaTimes size={18} />
                     </button>
                 </div>
@@ -48,7 +48,7 @@ export default function EditPage({ params }: { params: Promise<{ id: string }> }
             <div className="fixed inset-0 z-[60] bg-white dark:bg-gray-950 flex flex-col overflow-y-auto">
                 <div className="flex items-center gap-3 px-4 py-3 border-b border-gray-100 dark:border-gray-800 shrink-0">
                     <div className="flex-1 min-w-0"><p className="font-medium text-base">editor</p></div>
-                    <button onClick={() => router.back()} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-1 ml-1 transition-colors">
+                    <button onClick={() => router.back()} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-2 -m-1 ml-1 transition-colors touch-manipulation">
                         <FaTimes size={18} />
                     </button>
                 </div>

--- a/app/components/editor-modal.tsx
+++ b/app/components/editor-modal.tsx
@@ -2346,7 +2346,7 @@ export default function EditorModal({
               )
             })()}
           </div>
-          <button onClick={handleClose} data-testid="editor-close" className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-1 ml-1 transition-colors">
+          <button onClick={handleClose} data-testid="editor-close" className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 p-2 -m-1 ml-1 transition-colors touch-manipulation">
             <FaTimes size={13} />
           </button>
         </div>
@@ -2468,7 +2468,7 @@ export default function EditorModal({
                   data-testid="orig-play"
                   onClick={e => { e.stopPropagation(); switchToWaveform('orig'); if (origPlaying) wsOrigRef.current?.pause(); else { pausePlayer(); wsRef.current?.pause(); stopPreview(); wsOrigRef.current?.play() } }}
                   disabled={!origReady}
-                  className={`shrink-0 ${origReady ? 'text-sky-500 hover:text-sky-400' : 'text-gray-300 dark:text-gray-700'}`}
+                  className={`shrink-0 p-2 -m-1 touch-manipulation ${origReady ? 'text-sky-500 hover:text-sky-400' : 'text-gray-300 dark:text-gray-700'}`}
                 >
                   {origPlaying ? <FaPause size={12} /> : <FaPlay size={12} />}
                 </button>
@@ -2554,7 +2554,7 @@ export default function EditorModal({
 
               {/* transport row inside edit waveform card */}
               <div className="flex items-center gap-3 px-2 pb-2 border-t border-gray-100 dark:border-gray-800 pt-1.5" onClick={e => e.stopPropagation()}>
-                <button data-testid="editor-preview-btn" onClick={() => { switchToWaveform('edit'); handlePreview() }} disabled={!wsReady} title={previewing ? 'stop preview' : 'preview with edits'} className={`shrink-0 ${wsReady ? 'text-sky-500 hover:text-sky-400' : 'text-gray-300 dark:text-gray-700'}`}>
+                <button data-testid="editor-preview-btn" onClick={() => { switchToWaveform('edit'); handlePreview() }} disabled={!wsReady} title={previewing ? 'stop preview' : 'preview with edits'} className={`shrink-0 p-2 -m-1 touch-manipulation ${wsReady ? 'text-sky-500 hover:text-sky-400' : 'text-gray-300 dark:text-gray-700'}`}>
                   {previewing ? <FaPause size={12} /> : <FaPlay size={12} />}
                 </button>
 

--- a/app/components/nav-links.tsx
+++ b/app/components/nav-links.tsx
@@ -52,7 +52,7 @@ export default function NavLinks() {
                 {links.map(l => renderLink(l))}
             </div>
             <div className="sm:hidden">
-                <button onClick={() => setOpen(p => !p)} className="hover:text-sky-600">
+                <button onClick={() => setOpen(p => !p)} className="hover:text-sky-600 p-2 -m-1 touch-manipulation">
                     {open ? <FaTimes size={16} /> : <FaBars size={16} />}
                 </button>
                 {open && (

--- a/app/components/navbar.tsx
+++ b/app/components/navbar.tsx
@@ -15,10 +15,10 @@ export default function NavBar() {
                 <NavLinks />
             </div>
             <div className="flex flex-row gap-3 items-center">
-                <Link href={routes.info} className="hover:text-sky-600">
+                <Link href={routes.info} className="hover:text-sky-600 p-2 -m-1 touch-manipulation">
                     <FaInfoCircle size="16" />
                 </Link>
-                <Link href={routes.settings} className="hover:text-sky-600">
+                <Link href={routes.settings} className="hover:text-sky-600 p-2 -m-1 touch-manipulation">
                     <FaUser size="16" />
                 </Link>
                 <LogoutButton />

--- a/app/components/player.tsx
+++ b/app/components/player.tsx
@@ -1086,7 +1086,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                                                 {playContext.label}
                                             </Link>
                                         )}
-                                        <button onClick={() => { setShowQueue(false); setQueueSearch('') }} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1">
+                                        <button onClick={() => { setShowQueue(false); setQueueSearch('') }} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-2 -m-1 touch-manipulation">
                                             <FaTimes size={14} />
                                         </button>
                                     </div>
@@ -1170,7 +1170,7 @@ export function PlayerProvider({ children }: { children: React.ReactNode }) {
                                                             {song.source.label}
                                                         </Link>
                                                     )}
-                                                    <button data-testid="queue-remove" onClick={() => removeFromQueue(qi)} className="shrink-0 text-gray-300 dark:text-gray-600 hover:text-red-400 transition-colors p-1">
+                                                    <button data-testid="queue-remove" onClick={() => removeFromQueue(qi)} className="shrink-0 text-gray-300 dark:text-gray-600 hover:text-red-400 transition-colors p-2 -m-1 touch-manipulation">
                                                         <FaTimes size={10} />
                                                     </button>
                                                 </div>

--- a/app/components/query-error.tsx
+++ b/app/components/query-error.tsx
@@ -38,7 +38,7 @@ export default function QueryError({ error, retry, context, message }: { error: 
                     </code>
                     <button
                         onClick={copyError}
-                        className="shrink-0 p-1 text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors"
+                        className="shrink-0 p-2 -m-1 text-red-400 hover:text-red-600 dark:hover:text-red-300 transition-colors touch-manipulation"
                     >
                         {copied ? <FaCheck size={12} /> : <FaCopy size={12} />}
                     </button>

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -49,8 +49,7 @@ export default function Search() {
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
     const showResults = mode === 'song' && text.trim().length >= 2
-    const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
-    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, isMobile ? 4 : 6) : []
+    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -49,7 +49,7 @@ export default function Search() {
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
     const showResults = mode === 'song' && text.trim().length >= 2
-    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []) : []
+    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { usePathname, useSearchParams, useRouter } from "next/navigation"
+import { useSearchParams, useRouter } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
@@ -25,7 +25,6 @@ export default function Search() {
     const searchParams = useSearchParams()
     const router = useRouter()
     const { replace } = useRouter()
-    const pathname = usePathname()
     const inputRef = useRef<HTMLInputElement>(null)
     const queryClient = useQueryClient()
 
@@ -78,11 +77,9 @@ export default function Search() {
         setText(v)
         if (!v) {
             queryClient.setQueryData(['index-search', debouncedText], [])
-            const params = new URLSearchParams(searchParams)
-            params.delete('query')
-            params.delete('lookup')
-            params.delete('limit')
-            replace(`${pathname}?${params.toString()}`)
+        }
+        if (searchParams.get('query')) {
+            replace(routes.download)
         }
     }
 

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,6 +1,6 @@
 'use client'
 import { usePathname, useSearchParams, useRouter } from "next/navigation"
-import { useCallback, useMemo, useRef, useState } from "react"
+import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
 import { routes } from '../lib/routes'
@@ -28,6 +28,15 @@ export default function Search() {
     const pathname = usePathname()
     const inputRef = useRef<HTMLInputElement>(null)
     const queryClient = useQueryClient()
+
+    const [isDesktop, setIsDesktop] = useState(false)
+    useEffect(() => {
+        const mq = window.matchMedia('(min-width: 768px)')
+        setIsDesktop(mq.matches)
+        const handler = (e: MediaQueryListEvent) => setIsDesktop(e.matches)
+        mq.addEventListener('change', handler)
+        return () => mq.removeEventListener('change', handler)
+    }, [])
 
     const [text, setText] = useState(searchParams.get('query') ?? '')
     const [mode, setMode] = useState<Mode>((searchParams.get('mode') as Mode) ?? 'song')
@@ -97,8 +106,8 @@ export default function Search() {
     }, [playNow])
 
     return (
-        <div>
-            <form onSubmit={handleSubmit}>
+        <>
+            <form onSubmit={handleSubmit} className="sticky top-11 z-40 bg-[var(--background)]/90 backdrop-blur-md border-b border-gray-100 dark:border-gray-800 px-2">
                 <div className="flex flex-wrap gap-2 py-3 items-center">
                     {MODES.map(m => (
                         <button
@@ -145,9 +154,9 @@ export default function Search() {
                 </div>
             </form>
             {internalResults.length > 0 && (
-                <div data-testid="instant-results" className="pb-3">
-                    <p className="text-gray-400 text-sm pb-2">In Songbird's Library</p>
-                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 md:gap-6">
+                <div data-testid="instant-results" className="px-2 pb-3">
+                    <p className="text-gray-400 text-sm pb-2">{"In Songbird's Library"}</p>
+                    <div className={isDesktop ? "grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6" : "flex flex-col"}>
                         {internalResults.map(song => (
                             <Song
                                 key={song.songId}
@@ -157,6 +166,7 @@ export default function Search() {
                                 inLibrary={song.songId ? libraryIds.has(song.songId) : false}
                                 isPrivate={!!song.owner_id}
                                 showSource={true}
+                                compact={!isDesktop}
                             />
                         ))}
                     </div>
@@ -171,6 +181,6 @@ export default function Search() {
                     )}
                 </div>
             )}
-        </div>
+        </>
     )
 }

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,5 +1,5 @@
 'use client'
-import { useSearchParams, useRouter } from "next/navigation"
+import { useSearchParams, useRouter, usePathname } from "next/navigation"
 import { useCallback, useEffect, useMemo, useRef, useState } from "react"
 import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
@@ -23,8 +23,8 @@ const PLACEHOLDERS: Record<Mode, string> = {
 
 export default function Search() {
     const searchParams = useSearchParams()
+    const pathname = usePathname()
     const router = useRouter()
-    const { replace } = useRouter()
     const inputRef = useRef<HTMLInputElement>(null)
     const queryClient = useQueryClient()
 
@@ -59,6 +59,8 @@ export default function Search() {
     const showResults = mode === 'song' && text.trim().length >= 2
     const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
 
+    const itunesVisible = pathname !== routes.download
+
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()
         const params = new URLSearchParams(searchParams)
@@ -78,9 +80,14 @@ export default function Search() {
         if (!v) {
             queryClient.setQueryData(['index-search', debouncedText], [])
         }
-        if (searchParams.get('query')) {
-            replace(routes.download)
+        const params = new URLSearchParams(searchParams)
+        if (v.trim()) {
+            params.set('query', v.trim())
+        } else {
+            params.delete('query')
         }
+        params.set('mode', mode)
+        router.replace(`${routes.download}?${params.toString()}`)
     }
 
     function handleModeChange(m: Mode) {
@@ -92,7 +99,7 @@ export default function Search() {
         params.delete('lookup')
         params.delete('limit')
         params.set('mode', m)
-        replace(`${modeRoute(m)}?${params.toString()}`)
+        router.replace(`${modeRoute(m)}?${params.toString()}`)
     }
 
     const handleSongClick = useCallback((song: DownloadedSong) => {
@@ -167,7 +174,7 @@ export default function Search() {
                             />
                         ))}
                     </div>
-                    {text.trim().length >= 2 && !searchParams.get('query') && (
+                    {text.trim().length >= 2 && !itunesVisible && (
                         <button
                             type="button"
                             onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -49,8 +49,7 @@ export default function Search() {
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
     const showResults = mode === 'song' && text.trim().length >= 2
-    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
-    const hasSubmitted = searchParams.get('query') === text.trim() && text.trim().length > 0
+    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []) : []
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()
@@ -145,9 +144,9 @@ export default function Search() {
                     </button>
                 </div>
             </form>
-            {internalResults.length > 0 && !hasSubmitted && (
+            {internalResults.length > 0 && (
                 <div data-testid="instant-results" className="pb-3">
-                    <p className="text-xs text-gray-400 px-1 pb-2">songbird</p>
+                    <p className="text-gray-400 text-sm pb-2">In Songbird's Library</p>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 md:gap-6">
                         {internalResults.map(song => (
                             <Song
@@ -161,13 +160,13 @@ export default function Search() {
                             />
                         ))}
                     </div>
-                    {text.trim().length >= 2 && (
+                    {text.trim().length >= 2 && !searchParams.get('query') && (
                         <button
                             type="button"
                             onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}
                             className="text-xs text-sky-500 hover:text-sky-400 px-1 pt-2 text-left"
                         >
-                            search iTunes for &ldquo;{text.trim()}&rdquo; →
+                            also search iTunes for &ldquo;{text.trim()}&rdquo; →
                         </button>
                     )}
                 </div>

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,15 +1,14 @@
 'use client'
 import { usePathname, useSearchParams, useRouter } from "next/navigation"
-import { useMemo, useRef, useState } from "react"
-import { useQuery, keepPreviousData } from "@tanstack/react-query"
+import { useCallback, useMemo, useRef, useState } from "react"
+import { useQuery, useQueryClient, keepPreviousData } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
 import { routes } from '../lib/routes'
-import { fetchPropertiesFromIndex, fetchLibrary, DownloadedSong } from '../lib/data'
+import { fetchPropertiesFromIndex, fetchLibrary, DownloadedSong, toPlayableSong } from '../lib/data'
 import { useDebouncedValue } from '../lib/use-debounce'
 import { queryKeys } from '../lib/query-keys'
 import { usePlayer } from './player'
 import Song from './song'
-import { toPlayableSong } from '../lib/data'
 
 const MODES = ['song', 'album', 'url'] as const
 type Mode = typeof MODES[number]
@@ -28,6 +27,7 @@ export default function Search() {
     const { replace } = useRouter()
     const pathname = usePathname()
     const inputRef = useRef<HTMLInputElement>(null)
+    const queryClient = useQueryClient()
 
     const [text, setText] = useState(searchParams.get('query') ?? '')
     const [mode, setMode] = useState<Mode>((searchParams.get('mode') as Mode) ?? 'song')
@@ -48,7 +48,8 @@ export default function Search() {
     })
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
-    const internalResults: DownloadedSong[] = (indexResults ?? []).slice(0, 6)
+    const showResults = mode === 'song' && text.trim().length >= 2
+    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
     const hasSubmitted = searchParams.get('query') === text.trim() && text.trim().length > 0
 
     function handleSubmit(e: React.FormEvent) {
@@ -68,6 +69,7 @@ export default function Search() {
     function handleChange(v: string) {
         setText(v)
         if (!v) {
+            queryClient.setQueryData(['index-search', debouncedText], [])
             const params = new URLSearchParams(searchParams)
             params.delete('query')
             params.delete('lookup')
@@ -79,6 +81,7 @@ export default function Search() {
     function handleModeChange(m: Mode) {
         setMode(m)
         setText('')
+        queryClient.setQueryData(['index-search', debouncedText], [])
         const params = new URLSearchParams(searchParams)
         params.delete('query')
         params.delete('lookup')
@@ -86,6 +89,13 @@ export default function Search() {
         params.set('mode', m)
         replace(`${modeRoute(m)}?${params.toString()}`)
     }
+
+    const handleSongClick = useCallback((song: DownloadedSong) => {
+        if (song.songId) {
+            const ctx = { label: 'Downloads', href: routes.download, id: 'downloads' }
+            playNow(toPlayableSong(song, ctx))
+        }
+    }, [playNow])
 
     return (
         <div>
@@ -135,30 +145,27 @@ export default function Search() {
                     </button>
                 </div>
             </form>
-            {mode === 'song' && internalResults.length > 0 && !hasSubmitted && (
-                <div data-testid="instant-results" className="pb-3 flex flex-col gap-1">
-                    <p className="text-xs text-gray-400 px-1">in your library</p>
-                    {internalResults.map(song => (
-                        <Song
-                            key={song.songId}
-                            song={song}
-                            selected={song.songId ? current?.uuid === song.songId : false}
-                            onClick={() => {
-                                if (song.songId) {
-                                    const ctx = { label: 'Downloads', href: routes.download, id: 'downloads' }
-                                    playNow(toPlayableSong(song, ctx))
-                                }
-                            }}
-                            inLibrary={song.songId ? libraryIds.has(song.songId) : false}
-                            isPrivate={!!song.owner_id}
-                            showSource={true}
-                        />
-                    ))}
+            {internalResults.length > 0 && !hasSubmitted && (
+                <div data-testid="instant-results" className="pb-3">
+                    <p className="text-xs text-gray-400 px-1 pb-2">in your library</p>
+                    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 md:gap-6">
+                        {internalResults.map(song => (
+                            <Song
+                                key={song.songId}
+                                song={song}
+                                selected={song.songId ? current?.uuid === song.songId : false}
+                                onClick={() => handleSongClick(song)}
+                                inLibrary={song.songId ? libraryIds.has(song.songId) : false}
+                                isPrivate={!!song.owner_id}
+                                showSource={true}
+                            />
+                        ))}
+                    </div>
                     {text.trim().length >= 2 && (
                         <button
                             type="button"
                             onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}
-                            className="text-xs text-sky-500 hover:text-sky-400 px-1 pt-1 text-left"
+                            className="text-xs text-sky-500 hover:text-sky-400 px-1 pt-2 text-left"
                         >
                             search iTunes for &ldquo;{text.trim()}&rdquo; →
                         </button>

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -147,7 +147,7 @@ export default function Search() {
             </form>
             {internalResults.length > 0 && !hasSubmitted && (
                 <div data-testid="instant-results" className="pb-3">
-                    <p className="text-xs text-gray-400 px-1 pb-2">in your library</p>
+                    <p className="text-xs text-gray-400 px-1 pb-2">songbird</p>
                     <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-2 md:gap-6">
                         {internalResults.map(song => (
                             <Song

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -49,7 +49,8 @@ export default function Search() {
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
     const showResults = mode === 'song' && text.trim().length >= 2
-    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
+    const isMobile = typeof window !== 'undefined' && window.innerWidth < 768
+    const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, isMobile ? 4 : 6) : []
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,8 +1,15 @@
 'use client'
 import { usePathname, useSearchParams, useRouter } from "next/navigation"
-import { useRef, useState } from "react"
+import { useMemo, useRef, useState } from "react"
+import { useQuery } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
 import { routes } from '../lib/routes'
+import { fetchPropertiesFromIndex, fetchLibrary, DownloadedSong } from '../lib/data'
+import { useDebouncedValue } from '../lib/use-debounce'
+import { queryKeys } from '../lib/query-keys'
+import { usePlayer } from './player'
+import Song from './song'
+import { toPlayableSong } from '../lib/data'
 
 const MODES = ['song', 'album', 'url'] as const
 type Mode = typeof MODES[number]
@@ -24,6 +31,24 @@ export default function Search() {
 
     const [text, setText] = useState(searchParams.get('query') ?? '')
     const [mode, setMode] = useState<Mode>((searchParams.get('mode') as Mode) ?? 'song')
+    const debouncedText = useDebouncedValue(text, 300)
+    const { playNow, current } = usePlayer()
+
+    const { data: indexResults = [] } = useQuery({
+        queryKey: ['index-search', debouncedText],
+        queryFn: () => fetchPropertiesFromIndex(debouncedText),
+        enabled: mode === 'song' && debouncedText.trim().length >= 2,
+        retry: false,
+    })
+
+    const { data: libraryEntries = [] } = useQuery({
+        queryKey: queryKeys.library,
+        queryFn: fetchLibrary,
+    })
+    const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
+
+    const internalResults: DownloadedSong[] = (indexResults ?? []).slice(0, 6)
+    const hasSubmitted = searchParams.get('query') === text.trim() && text.trim().length > 0
 
     function handleSubmit(e: React.FormEvent) {
         e.preventDefault()
@@ -62,50 +87,84 @@ export default function Search() {
     }
 
     return (
-        <form onSubmit={handleSubmit}>
-            <div className="flex flex-wrap gap-2 py-3 items-center">
-                {MODES.map(m => (
+        <div>
+            <form onSubmit={handleSubmit}>
+                <div className="flex flex-wrap gap-2 py-3 items-center">
+                    {MODES.map(m => (
+                        <button
+                            key={m}
+                            type="button"
+                            onClick={() => handleModeChange(m)}
+                            className={`px-3 py-1 rounded-full text-sm transition-colors ${
+                                mode === m ? 'bg-sky-500 text-white' : 'text-gray-400 hover:text-sky-500'
+                            }`}
+                        >
+                            {m}
+                        </button>
+                    ))}
+                    <span className="text-gray-200 dark:text-gray-700 self-center px-1">·</span>
+                    <div className="relative flex items-center flex-1 min-w-48 max-w-sm">
+                        <FaSearch size={11} className="absolute left-3 text-gray-400 pointer-events-none" />
+                        <input
+                            ref={inputRef}
+                            data-testid="download-search"
+                            type={mode === 'url' ? 'url' : 'text'}
+                            value={text}
+                            onChange={e => handleChange(e.target.value)}
+                            onKeyDown={e => { if (e.key === 'Escape' && text) { handleChange(''); e.preventDefault() } }}
+                            placeholder={PLACEHOLDERS[mode]}
+                            className="w-full pl-8 pr-8 py-1.5 rounded-lg text-base md:text-sm bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 placeholder-gray-400 outline-none focus:ring-2 focus:ring-sky-500 invalid:ring-2 invalid:ring-red-500"
+                        />
+                        {text && (
+                            <button
+                                type="button"
+                                onClick={() => { handleChange(''); inputRef.current?.focus() }}
+                                className="absolute right-0 p-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors touch-manipulation"
+                            >
+                                <FaTimes size={11} />
+                            </button>
+                        )}
+                    </div>
                     <button
-                        key={m}
-                        type="button"
-                        onClick={() => handleModeChange(m)}
-                        className={`px-3 py-1 rounded-full text-sm transition-colors ${
-                            mode === m ? 'bg-sky-500 text-white' : 'text-gray-400 hover:text-sky-500'
-                        }`}
+                        type="submit"
+                        disabled={!text.trim()}
+                        className="px-3 py-1.5 rounded-lg text-sm bg-sky-500 text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-sky-600 transition-colors shrink-0"
                     >
-                        {m}
+                        {mode === 'url' ? 'download' : 'search'}
                     </button>
-                ))}
-                <span className="text-gray-200 dark:text-gray-700 self-center px-1">·</span>
-                <div className="relative flex items-center flex-1 min-w-48 max-w-sm">
-                    <FaSearch size={11} className="absolute left-3 text-gray-400 pointer-events-none" />
-                    <input
-                        ref={inputRef}
-                        type={mode === 'url' ? 'url' : 'text'}
-                        value={text}
-                        onChange={e => handleChange(e.target.value)}
-                        onKeyDown={e => { if (e.key === 'Escape' && text) { handleChange(''); e.preventDefault() } }}
-                        placeholder={PLACEHOLDERS[mode]}
-                        className="w-full pl-8 pr-8 py-1.5 rounded-lg text-base md:text-sm bg-gray-100 dark:bg-gray-900 text-gray-800 dark:text-gray-200 placeholder-gray-400 outline-none focus:ring-2 focus:ring-sky-500 invalid:ring-2 invalid:ring-red-500"
-                    />
-                    {text && (
+                </div>
+            </form>
+            {mode === 'song' && internalResults.length > 0 && !hasSubmitted && (
+                <div data-testid="instant-results" className="pb-3 flex flex-col gap-1">
+                    <p className="text-xs text-gray-400 px-1">in your library</p>
+                    {internalResults.map(song => (
+                        <Song
+                            key={song.songId}
+                            song={song}
+                            selected={song.songId ? current?.uuid === song.songId : false}
+                            onClick={() => {
+                                if (song.songId) {
+                                    const ctx = { label: 'Downloads', href: routes.download, id: 'downloads' }
+                                    playNow(toPlayableSong(song, ctx))
+                                }
+                            }}
+                            inLibrary={song.songId ? libraryIds.has(song.songId) : false}
+                            isPrivate={!!song.owner_id}
+                            showSource={true}
+                            compact={true}
+                        />
+                    ))}
+                    {text.trim().length >= 2 && (
                         <button
                             type="button"
-                            onClick={() => { handleChange(''); inputRef.current?.focus() }}
-                            className="absolute right-2 text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+                            onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}
+                            className="text-xs text-sky-500 hover:text-sky-400 px-1 pt-1 text-left"
                         >
-                            <FaTimes size={11} />
+                            search iTunes for &ldquo;{text.trim()}&rdquo; →
                         </button>
                     )}
                 </div>
-                <button
-                    type="submit"
-                    disabled={!text.trim()}
-                    className="px-3 py-1.5 rounded-lg text-sm bg-sky-500 text-white disabled:opacity-40 disabled:cursor-not-allowed hover:bg-sky-600 transition-colors shrink-0"
-                >
-                    {mode === 'url' ? 'download' : 'search'}
-                </button>
-            </div>
-        </form>
+            )}
+        </div>
     )
 }

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -1,7 +1,7 @@
 'use client'
 import { usePathname, useSearchParams, useRouter } from "next/navigation"
 import { useMemo, useRef, useState } from "react"
-import { useQuery } from "@tanstack/react-query"
+import { useQuery, keepPreviousData } from "@tanstack/react-query"
 import { FaSearch, FaTimes } from 'react-icons/fa'
 import { routes } from '../lib/routes'
 import { fetchPropertiesFromIndex, fetchLibrary, DownloadedSong } from '../lib/data'
@@ -38,6 +38,7 @@ export default function Search() {
         queryKey: ['index-search', debouncedText],
         queryFn: () => fetchPropertiesFromIndex(debouncedText),
         enabled: mode === 'song' && debouncedText.trim().length >= 2,
+        placeholderData: keepPreviousData,
         retry: false,
     })
 
@@ -151,7 +152,6 @@ export default function Search() {
                             inLibrary={song.songId ? libraryIds.has(song.songId) : false}
                             isPrivate={!!song.owner_id}
                             showSource={true}
-                            compact={true}
                         />
                     ))}
                     {text.trim().length >= 2 && (

--- a/app/components/song-picker-modal.tsx
+++ b/app/components/song-picker-modal.tsx
@@ -150,7 +150,7 @@ export default function SongPickerModal({
                                     : hasDisabled ? 'select eligible' : 'select all'}
                             </button>
                         )}
-                        <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-1">
+                        <button onClick={onClose} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 p-2 -m-1 touch-manipulation">
                             <FaTimes size={14} />
                         </button>
                     </div>

--- a/app/components/song.tsx
+++ b/app/components/song.tsx
@@ -342,7 +342,7 @@ function SongInner({ song, selected, onClick, inLibrary: initialInLibrary, cache
                     onClick={handleLibraryToggle}
                     aria-disabled={libraryPending}
                     title={inLibrary ? 'Remove from library' : 'Add to library'}
-                    className={`aria-disabled:opacity-40 cursor-pointer transition-colors ${inLibrary ? 'text-sky-500 hover:text-red-400' : 'text-gray-400 hover:text-sky-500'}`}
+                    className={`aria-disabled:opacity-40 cursor-pointer transition-colors p-2 -m-1 touch-manipulation ${inLibrary ? 'text-sky-500 hover:text-red-400' : 'text-gray-400 hover:text-sky-500'}`}
                 >
                     {inLibrary
                         ? <FaBookmark size={iconSz} />
@@ -351,7 +351,7 @@ function SongInner({ song, selected, onClick, inLibrary: initialInLibrary, cache
                 </button>
             )}
             {offlineCached && (
-                <button onClick={handleOfflineToggle} title="Remove offline copy" className="text-sky-400 hover:text-red-400 transition-colors cursor-pointer">
+                <button onClick={handleOfflineToggle} title="Remove offline copy" className="text-sky-400 hover:text-red-400 transition-colors cursor-pointer p-2 -m-1 touch-manipulation">
                     <FaCloudDownloadAlt size={iconSz} />
                 </button>
             )}

--- a/app/components/songs.tsx
+++ b/app/components/songs.tsx
@@ -167,8 +167,8 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
             {songs.length === 0
                 ? <p>no songs found.</p>
                 : <>
-                    {renderSection(downloaded, "downloaded")}
-                    {renderSection(fromItunes, "matches")}
+                    {renderSection(downloaded, "songbird")}
+                    {renderSection(fromItunes, "iTunes matches")}
                 </>
             }
 

--- a/app/components/songs.tsx
+++ b/app/components/songs.tsx
@@ -47,8 +47,6 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
         }
     }, [activeIndex, status])
 
-    const downloaded = songs.filter(s => s.songId !== undefined)
-    const fromItunes = songs.filter(s => s.songId === undefined)
     const activeSong = activeIndex !== noActiveIndex ? songs[activeIndex] : undefined
     const isDownloading = status === 'downloading' || status === 'tagging' || status === 'saving'
 
@@ -135,13 +133,10 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
                                 selected={song.songId ? current?.uuid === song.songId : activeIndex === globalIndex}
                                 onClick={() => {
                                     if (song.songId) {
-                                        // Source href captures the current URL so navigating back restores the user's
-                                        // search results / page state (e.g. /download/song?query=foo).
                                         const here = typeof window !== 'undefined'
                                             ? window.location.pathname + window.location.search
                                             : routes.download
                                         const ctx = { label: 'Downloads', href: here, id: 'downloads' }
-                                        const q = downloaded.filter(s => s.songId).map(s => toPlayableSong(s, ctx))
                                         playNow(toPlayableSong(song, ctx))
                                     } else {
                                         setActiveIndex(globalIndex)
@@ -166,10 +161,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
         <div className={activeSong ? 'pb-24' : ''}>
             {songs.length === 0
                 ? <p>no songs found.</p>
-                : <>
-                    {renderSection(downloaded, "songbird")}
-                    {renderSection(fromItunes, "iTunes matches")}
-                </>
+                : renderSection(songs, "iTunes Matches")
             }
 
             {activeSong && (

--- a/app/components/songs.tsx
+++ b/app/components/songs.tsx
@@ -176,7 +176,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
                 <div className="fixed left-0 right-0 z-[55] bg-white dark:bg-gray-900 border-t border-gray-200 dark:border-gray-700 shadow-2xl" style={{ bottom: 'var(--player-bar-h, 0px)' }}>
                     {status === 'ready' ? (
                         <div className="flex items-center gap-3 px-4 py-3">
-                            <button type="button" onClick={dismiss} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 transition-colors">
+                            <button type="button" onClick={dismiss} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 transition-colors p-2 -m-1 touch-manipulation">
                                 <FaX size={11} />
                             </button>
                             <div className="min-w-0 flex-1">
@@ -198,7 +198,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
                         </div>
                     ) : (
                         <form onSubmit={handleSongDownload} className="flex items-center gap-3 px-4 py-3">
-                            <button type="button" onClick={dismiss} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 transition-colors">
+                            <button type="button" onClick={dismiss} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 shrink-0 transition-colors p-2 -m-1 touch-manipulation">
                                 <FaX size={11} />
                             </button>
                             <div className="min-w-0 hidden sm:block shrink-0 w-40">

--- a/app/components/toast.tsx
+++ b/app/components/toast.tsx
@@ -61,7 +61,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
                 <div onClick={dismiss} data-testid={toast.error ? 'toast-error' : 'toast'} className={`fixed bottom-48 left-1/2 -translate-x-1/2 z-[80] px-4 py-2 rounded-full text-xs font-medium shadow-lg cursor-pointer max-w-[90vw] flex items-center gap-2 ${toast.error ? 'bg-red-100 text-red-800 dark:bg-red-900 dark:text-red-200' : 'bg-gray-100 text-gray-900 dark:bg-gray-900 dark:text-white'}`}>
                     <span className="truncate">{toast.msg}</span>
                     {toast.error && (
-                        <button onClick={handleCopy} className="shrink-0 p-0.5 hover:opacity-70 transition-opacity" title="copy error">
+                        <button onClick={handleCopy} className="shrink-0 p-2 -m-1 hover:opacity-70 transition-opacity touch-manipulation" title="copy error">
                             {copied ? <FaCheck size={10} /> : <FaCopy size={10} />}
                         </button>
                     )}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.5.4",
+  "version": "0.5.5",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Debounced instant internal search on download page (song mode, 2+ chars)
- iTunes search remains submit-only to avoid rate limiting
- All icon buttons now have 44px+ touch targets for mobile
- Settings audio format buttons stay grey until server state loads (no more mp3 flash)

## Test plan
- [ ] Type in download search bar — internal library results appear after 2 chars
- [ ] Press enter — full iTunes + internal results load
- [ ] Mobile: all icon buttons easy to tap
- [ ] Settings page: no format flash on load