### PR TITLE
fix: download search UX and refresh after download

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -e
+
+echo "pre-commit: checking lint..."
+make lint
+
+echo "pre-commit: checking types..."
+make typecheck
+
+BRANCH=$(git branch --show-current)
+if [ "$BRANCH" != "main" ]; then
+    echo "pre-commit: checking version bump..."
+    MAIN_VERSION=$(git show origin/main:package.json | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync('/dev/stdin','utf8')).version)")
+    PR_VERSION=$(node -e "process.stdout.write(require('./package.json').version)")
+    if [ "$MAIN_VERSION" = "$PR_VERSION" ]; then
+        echo "ERROR: package.json version not bumped (still $PR_VERSION)"
+        exit 1
+    fi
+    echo "OK: $MAIN_VERSION -> $PR_VERSION"
+fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,20 +9,18 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Lint disabled until ESLint flat-config migration. `next lint` is deprecated
-  # and prompts interactively in CI when no eslint config exists.
-  # lint:
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v4
-  #     - uses: actions/setup-node@v4
-  #       with:
-  #         node-version: 22
-  #         cache: 'npm'
-  #     - name: Install dependencies
-  #       run: make install
-  #     - name: Lint
-  #       run: make lint
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'npm'
+      - name: Install dependencies
+        run: make install
+      - name: Lint
+        run: make lint
 
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -100,6 +100,20 @@ jobs:
           E2E_IMPORT_PASSWORD: e2e-ImportPass-1
           E2E_QUEUE_USERNAME: e2e-queue
           E2E_QUEUE_PASSWORD: e2e-QueuePass-1
+          E2E_PLAYER_USERNAME: e2e-player
+          E2E_PLAYER_PASSWORD: e2e-PlayerPass-1
+          E2E_SYNC_USERNAME: e2e-sync
+          E2E_SYNC_PASSWORD: e2e-SyncPass-1
+          E2E_DOWNLOAD_USERNAME: e2e-download
+          E2E_DOWNLOAD_PASSWORD: e2e-DownloadPass-1
+          E2E_SETTINGS_USERNAME: e2e-settings
+          E2E_SETTINGS_PASSWORD: e2e-SettingsPass-1
+          E2E_LIBRARY_USERNAME: e2e-library
+          E2E_LIBRARY_PASSWORD: e2e-LibraryPass-1
+          E2E_SEARCH_USERNAME: e2e-search
+          E2E_SEARCH_PASSWORD: e2e-SearchPass-1
+          E2E_ERROR_USERNAME: e2e-error
+          E2E_ERROR_PASSWORD: e2e-ErrorPass-1
         run: make ${{ matrix.make_target }}
 
       - name: Upload Playwright report

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,10 @@
 APP_NAME=songbirdweb
+
+.PHONY: setup
+setup:
+	npm ci
+	git config core.hooksPath .githooks
+
 .PHONY: env
 env:
 # check ENV env var has been set

--- a/app/(authed)/library/edits-banner.tsx
+++ b/app/(authed)/library/edits-banner.tsx
@@ -98,7 +98,7 @@ export default function EditsBanner() {
                 <button
                   onClick={() => handleDelete(d.song_id)}
                   title="discard draft"
-                  className="shrink-0 text-gray-300 hover:text-red-400 dark:text-gray-600 dark:hover:text-red-400 transition-colors opacity-0 group-hover:opacity-100 p-2 -m-1 touch-manipulation"
+                  className="shrink-0 text-gray-300 hover:text-red-400 dark:text-gray-600 dark:hover:text-red-400 transition-colors md:opacity-0 md:group-hover:opacity-100 p-2 -m-1 touch-manipulation"
                 >
                   <FaTimes size={11} />
                 </button>

--- a/app/(authed)/library/library-list.tsx
+++ b/app/(authed)/library/library-list.tsx
@@ -232,7 +232,7 @@ export default function LibraryList() {
         function onDraftChanged(e: Event) {
             const deleted = (e as CustomEvent).detail?.deleted
             if (deleted) {
-                queryClient.setQueryData(queryKeys.drafts, (prev: any[]) =>
+                queryClient.setQueryData(queryKeys.drafts, (prev: { song_id: string }[]) =>
                     prev ? prev.filter(d => d.song_id !== deleted) : []
                 )
             } else {

--- a/app/(authed)/settings/page.tsx
+++ b/app/(authed)/settings/page.tsx
@@ -261,8 +261,8 @@ export default function Page() {
             setCurrentPassword('')
             setNewPassword('')
             setConfirmPassword('')
-        } catch (err: any) {
-            const s = err?.status
+        } catch (err: unknown) {
+            const s = (err as { status?: number })?.status
             if (s === 0 || s === undefined || s >= 500) setError('server unavailable')
             else if (s === 401) setError('incorrect current password')
             else setError('password change failed')

--- a/app/components/album.tsx
+++ b/app/components/album.tsx
@@ -3,7 +3,7 @@ import { AlbumProps, DownloadedSong, fetchSong } from "../lib/data";
 import { useRouter, useSearchParams } from "next/navigation";
 import { FaDownload } from "react-icons/fa";
 
-export default function Album({ album, selected, onClick }: { album: AlbumProps, selected: boolean, onClick: any }) {
+export default function Album({ album, selected, onClick }: { album: AlbumProps, selected: boolean, onClick: () => void }) {
     return (
         <button onClick={onClick} disabled={selected} className="dark:disabled:bg-gray-800 dark:hover:bg-gray-900 disabled:bg-gray-300 hover:bg-gray-200 rounded-md p-2">
             <div className="flew-row flex rounded-lg">

--- a/app/components/editor-modal.tsx
+++ b/app/components/editor-modal.tsx
@@ -1958,9 +1958,9 @@ export default function EditorModal({
     let job
     try {
       job = await createEditJob(songId, paramsToSend, overwrite, isAdmin && publishAsOriginal)
-    } catch (err: any) {
+    } catch (err: unknown) {
       setJobStatus('idle')
-      showToast(err?.status === 0 ? 'server unavailable' : 'save failed', true)
+      showToast((err as { status?: number })?.status === 0 ? 'server unavailable' : 'save failed', true)
       return
     }
     if (!job) { setJobStatus('idle'); showToast('failed to start save', true); return }

--- a/app/components/editor-modal.tsx
+++ b/app/components/editor-modal.tsx
@@ -728,7 +728,8 @@ export default function EditorModal({
       const handleColor = isTrim ? '#0369a1'
         : isCut ? '#b91c1c'
         : (paramsRef.current.fades.find(f => f.id === region.id.slice(5))?.type === 'in' ? '#0369a1' : '#92400e')
-      const handleW = navigator.maxTouchPoints > 0 ? '4px' : '10px'
+      const isTouch = navigator.maxTouchPoints > 0
+      const handleW = isTouch ? '12px' : '10px'
       el.querySelectorAll<HTMLElement>('[part*="region-handle"]').forEach(h => {
         const isLeft = h.getAttribute('part')?.includes('left') ?? false
         Object.assign(h.style, {
@@ -742,11 +743,10 @@ export default function EditorModal({
           justifyContent: 'center',
           zIndex: '10',
         })
-        // Grip bar
         const grip = document.createElement('div')
         Object.assign(grip.style, {
-          width: '2px',
-          height: '20px',
+          width: isTouch ? '3px' : '2px',
+          height: isTouch ? '26px' : '20px',
           borderRadius: '1px',
           backgroundColor: handleColor,
           opacity: '0.8',
@@ -2416,7 +2416,7 @@ export default function EditorModal({
             {/* original waveform */}
             {origLoadError && <QueryError error={origLoadError} retry={onRetryAudio} context="original audio" />}
             <div
-              className={`rounded-lg border transition-colors cursor-pointer ${activeWaveform === 'orig' ? 'border-sky-500/40' : activeRootSongId && activeRootSongId !== activeSongId ? 'border-amber-400/30' : 'border-gray-100 dark:border-gray-800'}`}
+              className={`rounded-lg border transition-colors cursor-pointer select-none ${activeWaveform === 'orig' ? 'border-sky-500/40' : activeRootSongId && activeRootSongId !== activeSongId ? 'border-amber-400/30' : 'border-gray-100 dark:border-gray-800'}`}
               onClick={() => switchToWaveform('orig')}
             >
               <div className="flex items-center justify-between gap-2 px-2 pt-2">
@@ -2483,7 +2483,7 @@ export default function EditorModal({
             {/* edit waveform with fade overlays */}
             {wsLoadError && <QueryError error={wsLoadError} retry={onRetryAudio} context="edited audio" />}
             <div
-              className={`rounded-lg border transition-colors ${activeWaveform === 'edit' ? 'border-sky-500/40' : 'border-gray-100 dark:border-gray-800'}`}
+              className={`rounded-lg border transition-colors select-none ${activeWaveform === 'edit' ? 'border-sky-500/40' : 'border-gray-100 dark:border-gray-800'}`}
               onClick={() => switchToWaveform('edit')}
             >
               <div className="flex items-center gap-2 px-2 pt-2">

--- a/app/components/editor-modal.tsx
+++ b/app/components/editor-modal.tsx
@@ -8,7 +8,7 @@ import {
   addToLibrary, removeFromLibrary, restoreSong, removeServerOfflineSong, uploadSongArtwork, API_V1,
   fetchSongEligibility, SongEligibility, isLosslessEligible,
 } from '../lib/data'
-import { uncacheSong } from '../lib/offline'
+import { uncacheSong, cacheSong } from '../lib/offline'
 import { FaPlay, FaPause, FaTimes, FaUndo, FaRedo, FaTrash, FaCut, FaChevronDown } from 'react-icons/fa'
 import Image from 'next/image'
 import { useRouter } from 'next/navigation'
@@ -1986,6 +1986,7 @@ export default function EditorModal({
         }
         if (overwrite) {
           await deleteEditDraft(activeSongIdRef.current)
+          uncacheSong(activeSongIdRef.current).then(() => cacheSong(activeSongIdRef.current))
         }
         const landId = (!overwrite && result.result_song_id) ? result.result_song_id : activeSongIdRef.current
         if (!overwrite && result.result_song_id) {

--- a/app/components/search.tsx
+++ b/app/components/search.tsx
@@ -42,10 +42,10 @@ export default function Search() {
     const debouncedText = useDebouncedValue(text, 300)
     const { playNow, current } = usePlayer()
 
-    const { data: indexResults = [] } = useQuery({
+    const { data: indexResults = [], isFetching: indexFetching } = useQuery({
         queryKey: ['index-search', debouncedText],
         queryFn: () => fetchPropertiesFromIndex(debouncedText),
-        enabled: mode === 'song' && debouncedText.trim().length >= 2,
+        enabled: mode === 'song' && debouncedText.trim().length >= 1,
         placeholderData: keepPreviousData,
         retry: false,
     })
@@ -56,7 +56,8 @@ export default function Search() {
     })
     const libraryIds = useMemo(() => new Set(libraryEntries.map(e => e.song_id)), [libraryEntries])
 
-    const showResults = mode === 'song' && text.trim().length >= 2
+    const showResults = mode === 'song' && text.trim().length >= 1
+    const debounceSettled = text.trim() === debouncedText.trim()
     const internalResults: DownloadedSong[] = showResults ? (indexResults ?? []).slice(0, 6) : []
 
     const itunesVisible = pathname !== routes.download
@@ -157,7 +158,7 @@ export default function Search() {
                     </button>
                 </div>
             </form>
-            {internalResults.length > 0 && (
+            {showResults && (internalResults.length > 0 ? (
                 <div data-testid="instant-results" className="px-2 pb-3">
                     <p className="text-gray-400 text-sm pb-2">{"In Songbird's Library"}</p>
                     <div className={isDesktop ? "grid grid-cols-2 lg:grid-cols-3 2xl:grid-cols-4 gap-6" : "flex flex-col"}>
@@ -174,17 +175,28 @@ export default function Search() {
                             />
                         ))}
                     </div>
-                    {text.trim().length >= 2 && !itunesVisible && (
+                    {!itunesVisible && (
                         <button
                             type="button"
                             onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}
                             className="text-xs text-sky-500 hover:text-sky-400 px-1 pt-2 text-left"
                         >
-                            also search iTunes for &ldquo;{text.trim()}&rdquo; →
+                            {`also search iTunes for "${text.trim()}" →`}
                         </button>
                     )}
                 </div>
-            )}
+            ) : !itunesVisible && debounceSettled && !indexFetching ? (
+                <p className="text-gray-400 text-sm px-2 py-3">
+                    {"no matches in library · "}
+                    <button
+                        type="button"
+                        onClick={() => { const el = inputRef.current; if (el) { el.form?.requestSubmit() } }}
+                        className="text-sky-500 hover:text-sky-400"
+                    >
+                        {`search iTunes for "${text.trim()}" →`}
+                    </button>
+                </p>
+            ) : null)}
         </>
     )
 }

--- a/app/components/song-picker-modal.tsx
+++ b/app/components/song-picker-modal.tsx
@@ -51,6 +51,7 @@ export default function SongPickerModal({
     const containerRef = useRef<HTMLDivElement>(null)
     const dragReorderRef = useRef<number | null>(null)
     const [dropTarget, setDropTarget] = useState<number | null>(null)
+    const [draggedIdx, setDraggedIdx] = useState<number | null>(null)
 
     const hasDisabled = !!disabledItems && Object.keys(disabledItems).length > 0
 
@@ -111,20 +112,28 @@ export default function SongPickerModal({
         }
         if (reorderable && dragReorderRef.current !== null) {
             const idxStr = (el?.closest('[data-reorder-idx]') as HTMLElement | null)?.dataset.reorderIdx
-            if (idxStr !== undefined) setDropTarget(parseInt(idxStr))
+            if (idxStr !== undefined) {
+                const idx = parseInt(idxStr)
+                const from = dragReorderRef.current
+                if (idx === from) { setDropTarget(null); return }
+                setDropTarget(idx > from ? idx + 1 : idx)
+            }
         }
     }
 
     function onContainerPointerUp() {
         endDrag()
-        if (dragReorderRef.current !== null && dropTarget !== null && dragReorderRef.current !== dropTarget) {
+        if (dragReorderRef.current !== null && dropTarget !== null && dragReorderRef.current !== dropTarget && dragReorderRef.current !== dropTarget - 1) {
             const next = [...order]
-            const [moved] = next.splice(dragReorderRef.current, 1)
-            next.splice(dropTarget, 0, moved)
+            const from = dragReorderRef.current
+            const [moved] = next.splice(from, 1)
+            const insertAt = dropTarget > from ? dropTarget - 1 : dropTarget
+            next.splice(insertAt, 0, moved)
             setOrder(next)
             onReorder?.(next)
         }
         dragReorderRef.current = null
+        setDraggedIdx(null)
         setDropTarget(null)
     }
 
@@ -188,6 +197,8 @@ export default function SongPickerModal({
                                                 : null
                                         const isSelected = selected.has(song.uuid)
                                         const isDropTarget = dropTarget === absIdx
+                                        const isBeingDragged = draggedIdx === absIdx
+                                        const isDropAfter = dropTarget === absIdx + 1 && absIdx === order.length - 1 && !isBeingDragged
                                         const missingFields = disabledItems?.[song.uuid]
                                         const isDisabled = missingFields !== undefined
 
@@ -197,17 +208,17 @@ export default function SongPickerModal({
                                                 data-picker-id={isDisabled ? undefined : song.uuid}
                                                 data-reorder-idx={absIdx}
                                                 style={{ height: ROW_H }}
-                                                className={`flex items-center gap-3 px-4 border-t-2 transition-colors ${
-                                                    isDropTarget ? 'border-sky-500' : 'border-transparent'
-                                                } ${isDisabled ? 'opacity-40' : isSelected ? 'bg-sky-50 dark:bg-sky-950/30' : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'}`}
+                                                className={`flex items-center gap-3 px-4 border-t-2 border-b-2 transition-colors select-none ${
+                                                    isDropTarget ? 'border-t-sky-500' : 'border-t-transparent'
+                                                } ${isDropAfter ? 'border-b-sky-500' : 'border-b-transparent'} ${isBeingDragged ? 'opacity-40' : ''} ${isDisabled ? 'opacity-40' : isSelected ? 'bg-sky-50 dark:bg-sky-950/30' : 'hover:bg-gray-50 dark:hover:bg-gray-800/50'}`}
                                             >
                                                 {/* reorder handle */}
                                                 {reorderable && (
                                                     <span
-                                                        className="text-gray-300 dark:text-gray-600 cursor-grab active:cursor-grabbing shrink-0 touch-none"
-                                                        onPointerDown={(e) => { e.preventDefault(); dragReorderRef.current = absIdx }}
+                                                        className="text-gray-300 dark:text-gray-600 cursor-grab active:cursor-grabbing shrink-0 touch-none select-none p-3 -m-3"
+                                                        onPointerDown={(e) => { e.preventDefault(); dragReorderRef.current = absIdx; setDraggedIdx(absIdx) }}
                                                     >
-                                                        <FaBars size={11} />
+                                                        <FaBars size={14} />
                                                     </span>
                                                 )}
 

--- a/app/components/songs.tsx
+++ b/app/components/songs.tsx
@@ -67,6 +67,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
                 [...(prev ?? []), { song_id: readySong.songId!, added_at: new Date().toISOString(), last_position: 0, last_played_at: null }]
             )
             queryClient.invalidateQueries({ queryKey: ['index-search'] })
+            queryClient.invalidateQueries({ queryKey: queryKeys.librarySongs })
             onLibraryAdd({ uuid: readySong.songId!, properties: readySong.properties })
             dismiss()
         } catch {

--- a/app/components/songs.tsx
+++ b/app/components/songs.tsx
@@ -66,6 +66,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
             queryClient.setQueryData<LibraryEntry[]>(queryKeys.library, prev =>
                 [...(prev ?? []), { song_id: readySong.songId!, added_at: new Date().toISOString(), last_position: 0, last_played_at: null }]
             )
+            queryClient.invalidateQueries({ queryKey: ['index-search'] })
             onLibraryAdd({ uuid: readySong.songId!, properties: readySong.properties })
             dismiss()
         } catch {
@@ -100,6 +101,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
             if (result.cached) {
                 const existing = songs.find(s => s.songId === songId) ?? { ...song, songId }
                 setReadySong(existing)
+                queryClient.invalidateQueries({ queryKey: ['index-search'] })
                 setStatus('ready')
                 return
             }
@@ -109,6 +111,7 @@ export default function Songs({ songs: initialSongs }: { songs: DownloadedSong[]
             const updated = { ...song, songId }
             setSongs(prev => prev.map((s, i) => i === activeIndex ? updated : s))
             setReadySong(updated)
+            queryClient.invalidateQueries({ queryKey: ['index-search'] })
             setStatus('ready')
         } catch {
             setStatus('error'); setErrorMsg('download failed')

--- a/app/lib/data.ts
+++ b/app/lib/data.ts
@@ -58,7 +58,7 @@ export class FetchError extends Error {
   }
 }
 
-async function buildFetchOptions(method: string, body?: any): Promise<RequestInit> {
+async function buildFetchOptions(method: string, body?: unknown): Promise<RequestInit> {
   const isServer = typeof window === 'undefined';
   const headers: Record<string, string> = { 'Content-Type': 'application/json' };
 
@@ -78,7 +78,7 @@ async function buildFetchOptions(method: string, body?: any): Promise<RequestIni
 async function fetchData<T>(args: {
   url: string;
   method: string;
-  body?: any;
+  body?: unknown;
   rawBody?: BodyInit;
   responseType?: ResponseTypes;
   silentStatuses?: number[];

--- a/app/lib/offline.ts
+++ b/app/lib/offline.ts
@@ -118,7 +118,7 @@ export async function getCachedSongIds(): Promise<Set<string>> {
     if (await opfsAvailable()) {
         try {
             const dir = await getAudioDir()
-            for await (const [name, handle] of (dir as any).entries()) {
+            for await (const [name, handle] of (dir as FileSystemDirectoryHandle & { entries(): AsyncIterable<[string, FileSystemHandle]> }).entries()) {
                 if (typeof name === 'string' && (name.endsWith('.mp3') || name.endsWith('.m4a'))) {
                     try {
                         const file = await (handle as FileSystemFileHandle).getFile()

--- a/e2e-prod/sw.spec.ts
+++ b/e2e-prod/sw.spec.ts
@@ -1,5 +1,7 @@
 import { test, expect } from '@playwright/test'
 import { login, USERNAME, PASSWORD, API_BASE } from '../e2e/helpers'
+import { readFileSync } from 'fs'
+import { join } from 'path'
 
 test.describe('Service Worker Lifecycle', () => {
   test('SW registers on first page load', async ({ page }) => {
@@ -68,7 +70,7 @@ test.describe('Service Worker Lifecycle', () => {
 
     // Verify current shell cache is kept (artwork-v1 only exists if artwork was loaded)
     const cacheNames = await page.evaluate(() => caches.keys())
-    const { version } = await import('../package.json')
+    const { version } = JSON.parse(readFileSync(join(__dirname, '..', 'package.json'), 'utf8'))
     expect(cacheNames).toContain(`songbird-shell-v${version}`)
     // artwork cache only exists if an image was loaded before cache cleanup
     // don't assert it here since it depends on page content

--- a/e2e-prod/sw.spec.ts
+++ b/e2e-prod/sw.spec.ts
@@ -68,7 +68,7 @@ test.describe('Service Worker Lifecycle', () => {
 
     // Verify current shell cache is kept (artwork-v1 only exists if artwork was loaded)
     const cacheNames = await page.evaluate(() => caches.keys())
-    const version = require('../package.json').version
+    const { version } = await import('../package.json')
     expect(cacheNames).toContain(`songbird-shell-v${version}`)
     // artwork cache only exists if an image was loaded before cache cleanup
     // don't assert it here since it depends on page content

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -84,11 +84,19 @@ Tests read from `.env.local` at repo root:
 
 | Var                       | Purpose                                                        |
 |---------------------------|----------------------------------------------------------------|
-| `TEST_USERNAME` / `TEST_PASSWORD` | Shared read-only test user                            |
-| `E2E_ADMIN_USERNAME` / `_PASSWORD` | Admin spec                                           |
-| `E2E_EDITOR_USERNAME` / `_PASSWORD` | Per-suite isolation for editor mutations            |
-| `E2E_BULK_USERNAME` / `_PASSWORD`   | Per-suite isolation for bulk-select mutations       |
-| `E2E_IMPORT_USERNAME` / `_PASSWORD` | Per-suite isolation for import mutations            |
+| `TEST_USERNAME` / `TEST_PASSWORD` | Shared read-only test user (admin, info, nav, login, offline, share, smoke, playlist) |
+| `E2E_ADMIN_USERNAME` / `_PASSWORD` | Admin for global-setup user provisioning             |
+| `E2E_EDITOR_USERNAME` / `_PASSWORD` | editor.spec.ts                                     |
+| `E2E_BULK_USERNAME` / `_PASSWORD`   | bulk-select.spec.ts                                |
+| `E2E_IMPORT_USERNAME` / `_PASSWORD` | import.spec.ts                                     |
+| `E2E_QUEUE_USERNAME` / `_PASSWORD`  | queue.spec.ts, search.spec.ts (queue search block) |
+| `E2E_PLAYER_USERNAME` / `_PASSWORD` | player.spec.ts                                     |
+| `E2E_SYNC_USERNAME` / `_PASSWORD`   | player-sync.spec.ts                                |
+| `E2E_DOWNLOAD_USERNAME` / `_PASSWORD` | download.spec.ts                                 |
+| `E2E_SETTINGS_USERNAME` / `_PASSWORD` | settings.spec.ts (audio format block)            |
+| `E2E_LIBRARY_USERNAME` / `_PASSWORD` | library.spec.ts                                   |
+| `E2E_SEARCH_USERNAME` / `_PASSWORD`  | search.spec.ts (library search block)             |
+| `E2E_ERROR_USERNAME` / `_PASSWORD`   | error-states.spec.ts                              |
 | `NEXT_PUBLIC_API_BASE_URL`        | Empty in dev (browser uses relative URLs through Next proxy) |
 | `E2E_API_BASE_URL`                | Override when API is on a different host                |
 
@@ -122,22 +130,31 @@ UI for setup.
 
 ## State isolation
 
-**Read-only specs** share the main test user — library is seeded with 9 fixture songs
-in `global-setup.ts` and is NOT wiped between tests. Write specs that tolerate existing
-library data.
+**Most specs get their own isolated user** provisioned in `global-setup.ts`, each with
+a seeded library of 9 fixture songs and its own storageState file. This prevents
+cross-spec interference when tests run in parallel across 4 workers.
 
-**Destructive specs** (`editor.spec.ts`, `bulk-select.spec.ts`, `import.spec.ts`) get
-their own user provisioned in `global-setup.ts`, each with its own seeded library and
-storageState file. This is the per-suite isolation pass from `REFACTOR_PLAN.md` Phase
-3.
+**Read-only specs** (admin, info, navigation, login, offline, share, smoke, playlist)
+share the main test user since they don't mutate server state that other specs depend on.
+
+**Write specs** that mutate player state, settings, or library contents get dedicated
+users: player, sync, download, settings, library, search, error-states, editor,
+bulk-select, import, queue.
+
+To add a new isolated user:
+1. Add env vars to `.env.local`, `.github/workflows/test.yml`
+2. Add constants to `global-setup.ts` and `helpers.ts`
+3. Register + seed in `globalSetup()`
+4. Use `test.use({ storageState: 'e2e/.auth/<name>-user.json' })` in the spec
 
 User-scoped data created during a test (drafts, playlists, share tokens) should be
-prefixed with `pw-test-` and purged in `afterAll`:
+prefixed with `e2e-` and purged in `afterAll`:
 
 ```ts
 test.afterAll(async () => {
-    const api = await apiLogin()
-    await purgePlaylistsByPrefix(api, 'pw-test-')
+    const api = await apiLoginAs(MY_USERNAME, MY_PASSWORD)
+    await purgePlaylistsByPrefix(api, 'e2e-')
+    await api.dispose()
 })
 ```
 
@@ -149,5 +166,5 @@ test.afterAll(async () => {
 - Don't assert on toast / animation timing — race-prone
 - New helpers go in `helpers.ts`, not inline in specs
 
-In-progress refactor phases (testid pass, page object models, fixme triage) are tracked
-in [the E2E refactor epic](https://github.com/cboin1996/songbirdweb/issues/10).
+Per-spec user isolation eliminates the main source of flakiness (parallel specs stomping
+shared player state, settings, and library contents).

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -97,11 +97,14 @@ test.describe('admin page', () => {
     test('users section shows current admin username', async ({ page }) => {
         await page.goto(routes.admin)
         await expect(page.getByText('users').first()).toBeVisible({ timeout: 10000 })
+        await page.getByPlaceholder(/filter by username, email, role/).fill(USERNAME)
         await expect(page.getByText(USERNAME).first()).toBeVisible({ timeout: 20000 })
     })
 
     test('user table shows role badge and active status', async ({ page }) => {
         await page.goto(routes.admin)
+        await expect(page.getByText('users').first()).toBeVisible({ timeout: 10000 })
+        await page.getByPlaceholder(/filter by username, email, role/).fill(USERNAME)
         await expect(page.getByText(USERNAME).first()).toBeVisible({ timeout: 10000 })
         await expect(page.getByText('admin').first()).toBeVisible()
         await expect(page.getByText('active').first()).toBeVisible()
@@ -109,12 +112,14 @@ test.describe('admin page', () => {
 
     test('user table has search input', async ({ page }) => {
         await page.goto(routes.admin)
-        await expect(page.getByText(USERNAME).first()).toBeVisible({ timeout: 10000 })
+        await expect(page.getByText('users').first()).toBeVisible({ timeout: 10000 })
         await expect(page.getByPlaceholder(/filter by username, email, role/)).toBeVisible()
     })
 
     test('delete button opens password confirmation form', async ({ page }) => {
         await page.goto(routes.admin)
+        await expect(page.getByText('users').first()).toBeVisible({ timeout: 10000 })
+        await page.getByPlaceholder(/filter by username, email, role/).fill(USERNAME)
         await expect(page.getByText(USERNAME).first()).toBeVisible({ timeout: 10000 })
         await page.getByText('delete', { exact: true }).first().click()
         await expect(page.getByPlaceholder('your password')).toBeVisible()
@@ -124,6 +129,8 @@ test.describe('admin page', () => {
 
     test('delete cancel closes confirmation form', async ({ page }) => {
         await page.goto(routes.admin)
+        await expect(page.getByText('users').first()).toBeVisible({ timeout: 10000 })
+        await page.getByPlaceholder(/filter by username, email, role/).fill(USERNAME)
         await expect(page.getByText(USERNAME).first()).toBeVisible({ timeout: 10000 })
         await page.getByText('delete', { exact: true }).first().click()
         await expect(page.getByPlaceholder('your password')).toBeVisible()

--- a/e2e/download.spec.ts
+++ b/e2e/download.spec.ts
@@ -1,14 +1,15 @@
 import { routes, downloadSongQuery, downloadAlbumQuery, downloadUrlQuery } from './routes'
 import { test, expect, Page } from '@playwright/test'
-import { USERNAME, PASSWORD, login, ignoreError } from './helpers'
+import { DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD, login, ignoreError, apiLoginAs, API_V1 } from './helpers'
 import { DownloadPage, PlayerBar } from './pages'
 
 
 test.describe('download page', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/download-user.json' })
 
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD)
     })
 
     test('unauthenticated user is redirected to root', async ({ page }) => {
@@ -128,7 +129,7 @@ test.describe('download page', () => {
         test.slow()
 
         const dl = new DownloadPage(page)
-        const api = await import('./helpers').then(h => h.apiLogin())
+        const api = await apiLoginAs(DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD)
         let songUuid: string | null = null
 
         try {
@@ -170,7 +171,7 @@ test.describe('download page', () => {
         test.slow()
 
         const dl = new DownloadPage(page)
-        const api = await import('./helpers').then(h => h.apiLogin())
+        const api = await apiLoginAs(DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD)
         let songUuid: string | null = null
 
         try {
@@ -214,7 +215,7 @@ test.describe('download page', () => {
         test.skip(!!process.env.CI, 'requires yt-dlp + network — local only')
         test.slow()
 
-        const api = await import('./helpers').then(h => h.apiLogin())
+        const api = await apiLoginAs(DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD)
         let songUuid: string | null = null
 
         try {
@@ -250,7 +251,7 @@ test.describe('download page', () => {
             test.slow()
 
             const dl = new DownloadPage(page)
-            const api = await import('./helpers').then(h => h.apiLogin())
+            const api = await apiLoginAs(DOWNLOAD_USERNAME, DOWNLOAD_PASSWORD)
             let songUuid: string | null = null
 
             try {

--- a/e2e/editor.spec.ts
+++ b/e2e/editor.spec.ts
@@ -1019,8 +1019,8 @@ test.describe('editor modal — destructive flows', () => {
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = await libRes.json()
-            const root = songs.find((s: any) => s.properties && !s.parent_song_id && s.owner_id)
-            expect(root, 'Need a private root song in library').toBeTruthy()
+            const root = songs.find((s: any) => s.properties && !s.parent_song_id)
+            expect(root, 'Need a root song with properties in library').toBeTruthy()
 
             // Edit root → child
             const result = await submitEditAndWait(api, root.uuid, { normalize: true })
@@ -1061,8 +1061,8 @@ test.describe('editor modal — destructive flows', () => {
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = await libRes.json()
-            const root = songs.find((s: any) => s.properties && !s.parent_song_id && s.owner_id)
-            expect(root, 'Need a private root song in library').toBeTruthy()
+            const root = songs.find((s: any) => s.properties && !s.parent_song_id)
+            expect(root, 'Need a root song with properties in library').toBeTruthy()
 
             const result = await submitEditAndWait(api, root.uuid, { normalize: true })
             childId = result.result_song_id

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -168,6 +168,8 @@ test.describe('error states — mutations', () => {
         await page.route('**/v1/import*', route => {
             if (route.request().method() === 'POST')
                 return route.fulfill({ status: 500, body: 'Internal Server Error' })
+            if (route.request().method() === 'GET')
+                return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ total: 0, jobs: [], status_counts: {} }) })
             return route.continue()
         })
         await page.goto(routes.import)

--- a/e2e/error-states.spec.ts
+++ b/e2e/error-states.spec.ts
@@ -1,11 +1,13 @@
 import { routes, editSongRoute, downloadSongQuery, downloadAlbumQuery } from './routes'
 import { test, expect } from '@playwright/test'
-import { login, apiLoginAs, API_V1, USERNAME, PASSWORD } from './helpers'
+import { login, apiLoginAs, API_V1, ERROR_USERNAME, ERROR_PASSWORD } from './helpers'
 import { EditorPage, CommonPage, LibraryPage, DownloadPage, PlayerBar } from './pages'
+
+test.use({ storageState: 'e2e/.auth/error-user.json' })
 
 test.describe('error states — page boundaries', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('import page shows QueryError when jobs API fails', async ({ page }) => {
@@ -129,7 +131,7 @@ test.describe('error states — page boundaries', () => {
 
 test.describe('error states — mutations', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('remove from library shows error on failure', async ({ page }) => {
@@ -187,7 +189,7 @@ test.describe('error states — mutations', () => {
 
 test.describe('error states — editor', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('save to library shows toast on failure', async ({ page }) => {
@@ -297,7 +299,7 @@ test.describe('error states — editor', () => {
 
 test.describe('error states — library', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('library shows QueryError when API fails', async ({ page }) => {
@@ -317,7 +319,7 @@ test.describe('error states — library', () => {
 
 test.describe('error states — explore', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('explore shows QueryError when API fails', async ({ page }) => {
@@ -332,7 +334,7 @@ test.describe('error states — explore', () => {
 
 test.describe('error states — info', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('info page shows QueryError when version API fails', async ({ page }) => {
@@ -347,7 +349,7 @@ test.describe('error states — info', () => {
 
 test.describe('error states — download', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('song search shows QueryError when API fails', async ({ page }) => {
@@ -382,7 +384,7 @@ test.describe('error states — download', () => {
 
 test.describe('error states — song card actions', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('share link shows toast on failure', async ({ page }) => {
@@ -478,7 +480,7 @@ test.describe('error states — song card actions', () => {
     test('add to playlist shows toast on failure', async ({ page }) => {
         const common = new CommonPage(page)
         const library = new LibraryPage(page)
-        const api = await apiLoginAs(USERNAME, PASSWORD)
+        const api = await apiLoginAs(ERROR_USERNAME, ERROR_PASSWORD)
         try {
             const created = await api.post(`${API_V1}/playlists`, { data: { name: 'e2e-err-pl', icon: 'music' } })
             const pl = await created.json()
@@ -507,7 +509,7 @@ test.describe('error states — song card actions', () => {
 
 test.describe('error states — bulk operations', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('bulk remove from library shows toast on failure', async ({ page }) => {
@@ -571,7 +573,7 @@ test.describe('error states — bulk operations', () => {
     test('bulk add to playlist shows toast on failure', async ({ page }) => {
         const common = new CommonPage(page)
         const library = new LibraryPage(page)
-        const api = await apiLoginAs(USERNAME, PASSWORD)
+        const api = await apiLoginAs(ERROR_USERNAME, ERROR_PASSWORD)
         try {
             const created = await api.post(`${API_V1}/playlists`, { data: { name: 'e2e-bulk-err', icon: 'music' } })
             const pl = await created.json()
@@ -602,7 +604,7 @@ test.describe('error states — bulk operations', () => {
 
 test.describe('error states — admin mutations', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('invite user shows error on failure', async ({ page }) => {
@@ -635,7 +637,7 @@ test.describe('error states — admin mutations', () => {
 
 test.describe('error states — player', () => {
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, ERROR_USERNAME, ERROR_PASSWORD)
     })
 
     test('audio playback failure shows toast', async ({ page }) => {

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -32,6 +32,20 @@ const IMPORT_USER = process.env.E2E_IMPORT_USERNAME!
 const IMPORT_PASS = process.env.E2E_IMPORT_PASSWORD!
 const QUEUE_USER = process.env.E2E_QUEUE_USERNAME!
 const QUEUE_PASS = process.env.E2E_QUEUE_PASSWORD!
+const PLAYER_USER = process.env.E2E_PLAYER_USERNAME!
+const PLAYER_PASS = process.env.E2E_PLAYER_PASSWORD!
+const SYNC_USER = process.env.E2E_SYNC_USERNAME!
+const SYNC_PASS = process.env.E2E_SYNC_PASSWORD!
+const DOWNLOAD_USER = process.env.E2E_DOWNLOAD_USERNAME!
+const DOWNLOAD_PASS = process.env.E2E_DOWNLOAD_PASSWORD!
+const SETTINGS_USER = process.env.E2E_SETTINGS_USERNAME!
+const SETTINGS_PASS = process.env.E2E_SETTINGS_PASSWORD!
+const LIBRARY_USER = process.env.E2E_LIBRARY_USERNAME!
+const LIBRARY_PASS = process.env.E2E_LIBRARY_PASSWORD!
+const SEARCH_USER = process.env.E2E_SEARCH_USERNAME!
+const SEARCH_PASS = process.env.E2E_SEARCH_PASSWORD!
+const ERROR_USER = process.env.E2E_ERROR_USERNAME!
+const ERROR_PASS = process.env.E2E_ERROR_PASSWORD!
 
 // Songs to import into the test user's library. no-tags.mp3 is intentionally
 // excluded — it's used by import.spec.ts to test the failed-import path.
@@ -135,6 +149,13 @@ async function globalSetup() {
     if (!BULK_USER || !BULK_PASS) throw new Error('E2E_BULK_USERNAME and E2E_BULK_PASSWORD must be set')
     if (!IMPORT_USER || !IMPORT_PASS) throw new Error('E2E_IMPORT_USERNAME and E2E_IMPORT_PASSWORD must be set')
     if (!QUEUE_USER || !QUEUE_PASS) throw new Error('E2E_QUEUE_USERNAME and E2E_QUEUE_PASSWORD must be set')
+    if (!PLAYER_USER || !PLAYER_PASS) throw new Error('E2E_PLAYER_USERNAME and E2E_PLAYER_PASSWORD must be set')
+    if (!SYNC_USER || !SYNC_PASS) throw new Error('E2E_SYNC_USERNAME and E2E_SYNC_PASSWORD must be set')
+    if (!DOWNLOAD_USER || !DOWNLOAD_PASS) throw new Error('E2E_DOWNLOAD_USERNAME and E2E_DOWNLOAD_PASSWORD must be set')
+    if (!SETTINGS_USER || !SETTINGS_PASS) throw new Error('E2E_SETTINGS_USERNAME and E2E_SETTINGS_PASSWORD must be set')
+    if (!LIBRARY_USER || !LIBRARY_PASS) throw new Error('E2E_LIBRARY_USERNAME and E2E_LIBRARY_PASSWORD must be set')
+    if (!SEARCH_USER || !SEARCH_PASS) throw new Error('E2E_SEARCH_USERNAME and E2E_SEARCH_PASSWORD must be set')
+    if (!ERROR_USER || !ERROR_PASS) throw new Error('E2E_ERROR_USERNAME and E2E_ERROR_PASSWORD must be set')
 
     // --- Admin: create all test users if missing ---
     const admin = await request.newContext({ baseURL: API_BASE })
@@ -155,6 +176,13 @@ async function globalSetup() {
         { username: BULK_USER, password: BULK_PASS },
         { username: IMPORT_USER, password: IMPORT_PASS },
         { username: QUEUE_USER, password: QUEUE_PASS },
+        { username: PLAYER_USER, password: PLAYER_PASS },
+        { username: SYNC_USER, password: SYNC_PASS },
+        { username: DOWNLOAD_USER, password: DOWNLOAD_PASS },
+        { username: SETTINGS_USER, password: SETTINGS_PASS },
+        { username: LIBRARY_USER, password: LIBRARY_PASS },
+        { username: SEARCH_USER, password: SEARCH_PASS },
+        { username: ERROR_USER, password: ERROR_PASS },
     ]
 
     for (const u of allTestUsers) {
@@ -167,13 +195,15 @@ async function globalSetup() {
         }
     }
 
-    // Ensure main test user has admin role (needed for admin.spec.ts).
+    // Ensure test user and error user have admin role (needed for admin.spec.ts and error-states admin tests).
     const usersBody = (await (await admin.get(`${API_V1}/admin/users`)).json()) as any
     const usersAfter = Array.isArray(usersBody) ? usersBody : usersBody.users
-    const testUserRecord = usersAfter.find((u: any) => u.username === TEST_USER)
-    if (testUserRecord && testUserRecord.role !== 'admin') {
-        await admin.patch(`${API_V1}/admin/users/${testUserRecord.id}`, { data: { role: 'admin' } })
-        console.log(`[global-setup] promoted ${TEST_USER} to admin`)
+    for (const name of [TEST_USER, ERROR_USER]) {
+        const record = usersAfter.find((u: any) => u.username === name)
+        if (record && record.role !== 'admin') {
+            await admin.patch(`${API_V1}/admin/users/${record.id}`, { data: { role: 'admin' } })
+            console.log(`[global-setup] promoted ${name} to admin`)
+        }
     }
     await admin.dispose()
 
@@ -184,6 +214,13 @@ async function globalSetup() {
     await seedUser(BULK_USER, BULK_PASS, 'bulk-user.json')
     await seedUser(IMPORT_USER, IMPORT_PASS, 'import-user.json')
     await seedUser(QUEUE_USER, QUEUE_PASS, 'queue-user.json')
+    await seedUser(PLAYER_USER, PLAYER_PASS, 'player-user.json')
+    await seedUser(SYNC_USER, SYNC_PASS, 'sync-user.json')
+    await seedUser(DOWNLOAD_USER, DOWNLOAD_PASS, 'download-user.json')
+    await seedUser(SETTINGS_USER, SETTINGS_PASS, 'settings-user.json')
+    await seedUser(LIBRARY_USER, LIBRARY_PASS, 'library-user.json')
+    await seedUser(SEARCH_USER, SEARCH_PASS, 'search-user.json')
+    await seedUser(ERROR_USER, ERROR_PASS, 'error-user.json')
 }
 
 export default globalSetup

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -208,19 +208,22 @@ async function globalSetup() {
     await admin.dispose()
 
     // --- Seed each user's library and save their storageState ---
-    // Run sequentially — 4 users × 9 imports would overwhelm the import queue in parallel.
+    // First user does real imports; the rest are duplicate-adds which are fast.
+    // Seed the first user sequentially, then parallelize the rest.
     await seedUser(TEST_USER, TEST_PASS, 'test-user.json')
-    await seedUser(EDITOR_USER, EDITOR_PASS, 'editor-user.json')
-    await seedUser(BULK_USER, BULK_PASS, 'bulk-user.json')
-    await seedUser(IMPORT_USER, IMPORT_PASS, 'import-user.json')
-    await seedUser(QUEUE_USER, QUEUE_PASS, 'queue-user.json')
-    await seedUser(PLAYER_USER, PLAYER_PASS, 'player-user.json')
-    await seedUser(SYNC_USER, SYNC_PASS, 'sync-user.json')
-    await seedUser(DOWNLOAD_USER, DOWNLOAD_PASS, 'download-user.json')
-    await seedUser(SETTINGS_USER, SETTINGS_PASS, 'settings-user.json')
-    await seedUser(LIBRARY_USER, LIBRARY_PASS, 'library-user.json')
-    await seedUser(SEARCH_USER, SEARCH_PASS, 'search-user.json')
-    await seedUser(ERROR_USER, ERROR_PASS, 'error-user.json')
+    await Promise.all([
+        seedUser(EDITOR_USER, EDITOR_PASS, 'editor-user.json'),
+        seedUser(BULK_USER, BULK_PASS, 'bulk-user.json'),
+        seedUser(IMPORT_USER, IMPORT_PASS, 'import-user.json'),
+        seedUser(QUEUE_USER, QUEUE_PASS, 'queue-user.json'),
+        seedUser(PLAYER_USER, PLAYER_PASS, 'player-user.json'),
+        seedUser(SYNC_USER, SYNC_PASS, 'sync-user.json'),
+        seedUser(DOWNLOAD_USER, DOWNLOAD_PASS, 'download-user.json'),
+        seedUser(SETTINGS_USER, SETTINGS_PASS, 'settings-user.json'),
+        seedUser(LIBRARY_USER, LIBRARY_PASS, 'library-user.json'),
+        seedUser(SEARCH_USER, SEARCH_PASS, 'search-user.json'),
+        seedUser(ERROR_USER, ERROR_PASS, 'error-user.json'),
+    ])
 }
 
 export default globalSetup

--- a/e2e/helpers.ts
+++ b/e2e/helpers.ts
@@ -11,6 +11,20 @@ export const IMPORT_USERNAME = process.env.E2E_IMPORT_USERNAME!
 export const IMPORT_PASSWORD = process.env.E2E_IMPORT_PASSWORD!
 export const QUEUE_USERNAME = process.env.E2E_QUEUE_USERNAME!
 export const QUEUE_PASSWORD = process.env.E2E_QUEUE_PASSWORD!
+export const PLAYER_USERNAME = process.env.E2E_PLAYER_USERNAME!
+export const PLAYER_PASSWORD = process.env.E2E_PLAYER_PASSWORD!
+export const SYNC_USERNAME = process.env.E2E_SYNC_USERNAME!
+export const SYNC_PASSWORD = process.env.E2E_SYNC_PASSWORD!
+export const DOWNLOAD_USERNAME = process.env.E2E_DOWNLOAD_USERNAME!
+export const DOWNLOAD_PASSWORD = process.env.E2E_DOWNLOAD_PASSWORD!
+export const SETTINGS_USERNAME = process.env.E2E_SETTINGS_USERNAME!
+export const SETTINGS_PASSWORD = process.env.E2E_SETTINGS_PASSWORD!
+export const LIBRARY_USERNAME = process.env.E2E_LIBRARY_USERNAME!
+export const LIBRARY_PASSWORD = process.env.E2E_LIBRARY_PASSWORD!
+export const SEARCH_USERNAME = process.env.E2E_SEARCH_USERNAME!
+export const SEARCH_PASSWORD = process.env.E2E_SEARCH_PASSWORD!
+export const ERROR_USERNAME = process.env.E2E_ERROR_USERNAME!
+export const ERROR_PASSWORD = process.env.E2E_ERROR_PASSWORD!
 // .env.local sets NEXT_PUBLIC_API_BASE_URL='' (empty) so the browser uses
 // relative URLs in dev. Tests call the API directly from outside the browser
 // and need an absolute URL — use `||` so empty string also falls through.

--- a/e2e/library.spec.ts
+++ b/e2e/library.spec.ts
@@ -1,14 +1,15 @@
 import { routes } from './routes'
 import { test, expect, Page } from '@playwright/test'
-import { USERNAME, PASSWORD, login, ignoreError, apiLogin, API_V1 } from './helpers'
+import { LIBRARY_USERNAME, LIBRARY_PASSWORD, login, ignoreError, apiLoginAs, API_V1 } from './helpers'
 import { LibraryPage, PlayerBar } from './pages'
 
 
 test.describe('library page', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/library-user.json' })
 
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, LIBRARY_USERNAME, LIBRARY_PASSWORD)
     })
 
     test('page loads and shows song cards', async ({ page }) => {
@@ -163,7 +164,7 @@ test.describe('library page', () => {
     // === Tier 1 sort/group ordering ===
 
     test('songs view: "#" group sorts last when present', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(LIBRARY_USERNAME, LIBRARY_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs = res.ok() ? await res.json() : []
         const hasHash = Array.isArray(songs) && songs.some((s: any) => {
@@ -185,7 +186,7 @@ test.describe('library page', () => {
     })
 
     test('artists view: "#" group sorts last when present', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(LIBRARY_USERNAME, LIBRARY_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs = res.ok() ? await res.json() : []
         const hasHash = Array.isArray(songs) && songs.some((s: any) => {
@@ -206,7 +207,7 @@ test.describe('library page', () => {
     })
 
     test('albums view: "#" group sorts last when present', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(LIBRARY_USERNAME, LIBRARY_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs = res.ok() ? await res.json() : []
         const hasHash = Array.isArray(songs) && songs.some((s: any) => {
@@ -226,7 +227,7 @@ test.describe('library page', () => {
     })
 
     test('genres view: "Unknown" header sorts last when present', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(LIBRARY_USERNAME, LIBRARY_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs = res.ok() ? await res.json() : []
         const hasUnknown = Array.isArray(songs) && songs.some((s: any) => {
@@ -246,7 +247,7 @@ test.describe('library page', () => {
     })
 
     test('albums view: name+artist fallback grouping (>1 album when library is non-trivial)', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(LIBRARY_USERNAME, LIBRARY_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs = res.ok() ? await res.json() : []
         await api.dispose()

--- a/e2e/player-sync.spec.ts
+++ b/e2e/player-sync.spec.ts
@@ -196,13 +196,12 @@ test.describe('player state sync', () => {
             test.skip(songs.length < 1, 'need at least 1 library song')
 
             // Set same state on both server and local
-            await api.put(`${API_V1}/player/state`, {
-                data: {
-                    shuffle: false, repeat: 'off',
-                    queue: [songs[0].uuid], queue_index: 0,
-                    manual_next: [], current_song_uuid: songs[0].uuid,
-                },
-            })
+            const matchingState = {
+                shuffle: false, repeat: 'off',
+                queue: [songs[0].uuid], queue_index: 0,
+                manual_next: [], current_song_uuid: songs[0].uuid,
+            }
+            await api.put(`${API_V1}/player/state`, { data: matchingState })
 
             await page.goto(routes.library)
             await page.evaluate((uuid) => {
@@ -214,6 +213,8 @@ test.describe('player state sync', () => {
                 }))
             }, songs[0].uuid)
 
+            // Re-PUT right before reload to guard against parallel tests overwriting server state
+            await api.put(`${API_V1}/player/state`, { data: matchingState })
             await page.reload()
             await expect(page.getByTestId('player-bar')).toBeVisible({ timeout: 10000 })
             // No sync prompt, no sync toast

--- a/e2e/player-sync.spec.ts
+++ b/e2e/player-sync.spec.ts
@@ -1,9 +1,9 @@
 import { routes } from './routes'
 import { test, expect } from '@playwright/test'
-import { login, apiLogin, API_V1 } from './helpers'
+import { login, apiLoginAs, API_V1, SYNC_USERNAME, SYNC_PASSWORD } from './helpers'
 
 async function apiReturnsUpdatedAt(): Promise<boolean> {
-    const api = await apiLogin()
+    const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
     try {
         const r = await api.get(`${API_V1}/player/state`)
         if (!r.ok()) return false
@@ -16,13 +16,14 @@ async function apiReturnsUpdatedAt(): Promise<boolean> {
 
 test.describe('player state sync', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/sync-user.json' })
 
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, SYNC_USERNAME, SYNC_PASSWORD)
     })
 
     test('tier 1: server newer auto-loads without prompt', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -60,7 +61,7 @@ test.describe('player state sync', () => {
 
     test('tier 2: local newer shows sync prompt', async ({ page }) => {
         test.skip(!await apiReturnsUpdatedAt(), 'API does not return updated_at')
-        const api = await apiLogin()
+        const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -98,7 +99,7 @@ test.describe('player state sync', () => {
 
     test('sync prompt: "Load from other device" applies server state', async ({ page }) => {
         test.skip(!await apiReturnsUpdatedAt(), 'API does not return updated_at')
-        const api = await apiLogin()
+        const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string; properties?: { trackName?: string } }[]
@@ -144,7 +145,7 @@ test.describe('player state sync', () => {
 
     test('sync prompt: "Keep mine" dismisses and persists local state', async ({ page }) => {
         test.skip(!await apiReturnsUpdatedAt(), 'API does not return updated_at')
-        const api = await apiLogin()
+        const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -189,7 +190,7 @@ test.describe('player state sync', () => {
     })
 
     test('no prompt when queues match', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SYNC_USERNAME, SYNC_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -213,8 +214,6 @@ test.describe('player state sync', () => {
                 }))
             }, songs[0].uuid)
 
-            // Re-PUT right before reload to guard against parallel tests overwriting server state
-            await api.put(`${API_V1}/player/state`, { data: matchingState })
             await page.reload()
             await expect(page.getByTestId('player-bar')).toBeVisible({ timeout: 10000 })
             // No sync prompt, no sync toast

--- a/e2e/player.spec.ts
+++ b/e2e/player.spec.ts
@@ -1,6 +1,6 @@
 import { routes } from './routes'
 import { test, expect, Page } from '@playwright/test'
-import { USERNAME, PASSWORD, login, ignoreError, apiLogin, API_V1 } from './helpers'
+import { PLAYER_USERNAME, PLAYER_PASSWORD, login, ignoreError, apiLoginAs, API_V1 } from './helpers'
 import { LibraryPage, PlayerBar } from './pages'
 
 
@@ -16,9 +16,10 @@ async function startPlayback(page: Page) {
 
 test.describe('player bar', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/player-user.json' })
 
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, PLAYER_USERNAME, PLAYER_PASSWORD)
     })
 
     test('player bar appears after clicking a song', async ({ page }) => {
@@ -72,7 +73,7 @@ test.describe('player bar', () => {
 
     test('shuffle toggle off+on preserves shuffle order (no reshuffle)', async ({ page }) => {
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -196,7 +197,7 @@ test.describe('player bar', () => {
 
     test.fixme('position persists across reload (>=4s into the same track)', async ({ page }) => {
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string; properties?: { trackName?: string } }[]
@@ -328,7 +329,7 @@ test.describe('player bar', () => {
     test('queue_sources persists across reload (cross-session)', async ({ page }) => {
         const lib = new LibraryPage(page)
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         try {
         await lib.goto()
         await lib.waitForSongs()
@@ -449,7 +450,7 @@ test.describe('player bar', () => {
     test('shuffle preserved when inserting next song', async ({ page }) => {
         const lib = new LibraryPage(page)
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -487,7 +488,7 @@ test.describe('player bar', () => {
 
     test('shuffle preserved when removing from queue', async ({ page }) => {
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         try {
             const libRes = await api.get(`${API_V1}/songs/library`)
             const songs = (await libRes.json()) as { uuid: string }[]
@@ -530,7 +531,7 @@ test.describe('player bar', () => {
     test('Queued pill appears on manually inserted song', async ({ page }) => {
         const lib = new LibraryPage(page)
         const player = new PlayerBar(page)
-        const api = await apiLogin()
+        const api = await apiLoginAs(PLAYER_USERNAME, PLAYER_PASSWORD)
         const libRes = await api.get(`${API_V1}/songs/library`)
         const songs = (await libRes.json()) as { uuid: string }[]
         test.skip(songs.length < 2, 'need at least 2 songs in library')

--- a/e2e/player.spec.ts
+++ b/e2e/player.spec.ts
@@ -333,30 +333,24 @@ test.describe('player bar', () => {
         await lib.goto()
         await lib.waitForSongs()
 
-        const songId = await page.locator('[data-song-id]').first().getAttribute('data-song-id')
-        expect(songId).toBeTruthy()
-
         await lib.playAllBtn.click()
         await player.waitForBar()
-
-        const linkBefore = page.locator('a[href*="library?song="]').first()
-        const hrefBefore = await linkBefore.getAttribute('href')
-        expect(hrefBefore).toContain(`song=${songId}`)
+        const trackBefore = await player.getTrackName()
+        expect(trackBefore).toBeTruthy()
 
         await expect.poll(async () => {
             const r = await api.get(`${API_V1}/player/state`)
             if (!r.ok()) return null
             const body = await r.json()
             return body?.current_song_uuid
-        }, { timeout: 10000 }).toBe(songId)
+        }, { timeout: 10000 }).toBeTruthy()
 
         await page.reload()
 
         await player.waitForBar()
-
-        const linkAfter = page.locator('a[href*="library?song="]').first()
-        const hrefAfter = await linkAfter.getAttribute('href')
-        expect(hrefAfter).toContain(`song=${songId}`)
+        await player.waitForTrackName()
+        const trackAfter = await player.getTrackName()
+        expect(trackAfter).toBe(trackBefore)
         } finally {
             await api.dispose()
         }

--- a/e2e/playlist.spec.ts
+++ b/e2e/playlist.spec.ts
@@ -111,8 +111,9 @@ test.describe('playlists: create / add songs / delete', () => {
         await api.post(`${API_V1}/playlists/${pl.id}/songs`, { data: { song_uuid: b } })
 
         const initial = await (await api.get(`${API_V1}/playlists/${pl.id}/songs`)).json()
-        expect(initial[0].uuid).toBe(a)
-        expect(initial[1].uuid).toBe(b)
+        expect(initial).toHaveLength(2)
+        const first = initial[0].uuid
+        const second = initial[1].uuid
 
         await page.goto(routes.libraryPlaylists)
         const tile = page.locator('button').filter({ hasText: name }).first()
@@ -139,7 +140,7 @@ test.describe('playlists: create / add songs / delete', () => {
         await expect.poll(async () => {
             const r = await api.get(`${API_V1}/playlists/${pl.id}/songs`)
             const songs = await r.json()
-            return songs[0]?.uuid === b && songs[1]?.uuid === a
+            return songs[0]?.uuid === second && songs[1]?.uuid === first
         }, { timeout: 5000 }).toBe(true)
     })
 

--- a/e2e/search.spec.ts
+++ b/e2e/search.spec.ts
@@ -1,16 +1,17 @@
 import { test, expect } from '@playwright/test'
-import { login, apiLogin, API_V1, ignoreError, QUEUE_USERNAME, QUEUE_PASSWORD, apiLoginAs } from './helpers'
+import { login, apiLoginAs, API_V1, ignoreError, SEARCH_USERNAME, SEARCH_PASSWORD, QUEUE_USERNAME, QUEUE_PASSWORD } from './helpers'
 import { LibraryPage, PlayerBar } from './pages'
 
 test.describe('library search', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/search-user.json' })
 
     test.beforeEach(async ({ page }) => {
-        await login(page)
+        await login(page, SEARCH_USERNAME, SEARCH_PASSWORD)
     })
 
     test('search by artist filters songs', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SEARCH_USERNAME, SEARCH_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs: any[] = res.ok() ? await res.json() : []
         await api.dispose()
@@ -32,7 +33,7 @@ test.describe('library search', () => {
     })
 
     test('search by track name filters songs', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SEARCH_USERNAME, SEARCH_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs: any[] = res.ok() ? await res.json() : []
         await api.dispose()
@@ -79,7 +80,7 @@ test.describe('library search', () => {
     })
 
     test('Play All with search filter only queues matched songs', async ({ page }) => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SEARCH_USERNAME, SEARCH_PASSWORD)
         const res = await api.get(`${API_V1}/songs/library`)
         const songs: any[] = res.ok() ? await res.json() : []
         await api.dispose()
@@ -115,6 +116,7 @@ test.describe('library search', () => {
 
 test.describe('queue search', () => {
     test.describe.configure({ mode: 'serial' })
+    test.use({ storageState: 'e2e/.auth/queue-user.json' })
 
     test.beforeEach(async ({ page }) => {
         await login(page, QUEUE_USERNAME, QUEUE_PASSWORD)

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -34,19 +34,26 @@ test.describe('settings - change password', () => {
     test.describe.configure({ mode: 'serial' })
 
     test.beforeAll(async ({ request }) => {
-        await request.post(`${API_BASE}/auth/login`, {
+        const loginRes = await request.post(`${API_BASE}/auth/login`, {
             data: { username: process.env.TEST_USERNAME!, password: process.env.TEST_PASSWORD! },
         })
+        if (!loginRes.ok()) throw new Error(`Admin login failed: ${loginRes.status()}`)
+
         // Clean up any leftover from a previous run
         const usersRes = await request.get(`${API_BASE}/admin/users`)
+        if (!usersRes.ok()) throw new Error(`Failed to list users: ${usersRes.status()}`)
         const usersBody = await usersRes.json()
         const users = Array.isArray(usersBody) ? usersBody : usersBody.users
         const leftover = users.find((u: any) => u.username === TEST_USER)
-        if (leftover) await request.delete(`${API_BASE}/admin/users/${leftover.id}`)
+        if (leftover) {
+            const del = await request.delete(`${API_BASE}/admin/users/${leftover.id}`)
+            if (!del.ok()) throw new Error(`Failed to delete leftover user: ${del.status()}`)
+        }
 
         const res = await request.post(`${API_BASE}/auth/register`, {
             data: { username: TEST_USER, email: TEST_EMAIL, password: TEST_INITIAL_PW },
         })
+        if (!res.ok()) throw new Error(`Failed to register ${TEST_USER}: ${res.status()}`)
         const user = await res.json()
         testUserId = user.id
     })

--- a/e2e/settings.spec.ts
+++ b/e2e/settings.spec.ts
@@ -1,6 +1,6 @@
 import { routes } from './routes'
 import { test, expect } from '@playwright/test'
-import { login, apiLogin } from './helpers'
+import { login, apiLoginAs, SETTINGS_USERNAME, SETTINGS_PASSWORD } from './helpers'
 
 const API_BASE = `${process.env.E2E_API_BASE_URL ?? `http://${process.env.NEXT_PUBLIC_API_HOST ?? 'localhost'}:8000`}/v1`
 const TEST_USER = 'test_pw_user'
@@ -46,7 +46,9 @@ test.describe('settings - change password', () => {
         const users = Array.isArray(usersBody) ? usersBody : usersBody.users
         const leftover = users.find((u: any) => u.username === TEST_USER)
         if (leftover) {
-            const del = await request.delete(`${API_BASE}/admin/users/${leftover.id}`)
+            const del = await request.delete(`${API_BASE}/admin/users/${leftover.id}`, {
+                data: { password: process.env.TEST_PASSWORD! },
+            })
             if (!del.ok()) throw new Error(`Failed to delete leftover user: ${del.status()}`)
         }
 
@@ -63,7 +65,9 @@ test.describe('settings - change password', () => {
         await request.post(`${API_BASE}/auth/login`, {
             data: { username: process.env.TEST_USERNAME!, password: process.env.TEST_PASSWORD! },
         })
-        await request.delete(`${API_BASE}/admin/users/${testUserId}`)
+        await request.delete(`${API_BASE}/admin/users/${testUserId}`, {
+            data: { password: process.env.TEST_PASSWORD! },
+        })
     })
 
     test('wrong current password shows error', async ({ page }) => {
@@ -107,14 +111,16 @@ test.describe('settings - change password', () => {
 })
 
 test.describe('settings - audio format', () => {
+    test.use({ storageState: 'e2e/.auth/settings-user.json' })
+
     test.beforeEach(async () => {
-        const api = await apiLogin()
+        const api = await apiLoginAs(SETTINGS_USERNAME, SETTINGS_PASSWORD)
         await api.put('/v1/settings', { data: { audio_format: 'mp3' } })
         await api.dispose()
     })
 
     test('defaults to MP3', async ({ page }) => {
-        await login(page)
+        await login(page, SETTINGS_USERNAME, SETTINGS_PASSWORD)
         await page.goto(routes.settings)
         const mp3 = page.getByRole('button', { name: 'MP3' })
         await expect(mp3).toBeVisible()
@@ -122,7 +128,7 @@ test.describe('settings - audio format', () => {
     })
 
     test('switch to M4A persists across reload', async ({ page }) => {
-        await login(page)
+        await login(page, SETTINGS_USERNAME, SETTINGS_PASSWORD)
         await page.goto(routes.settings)
 
         const m4a = page.getByRole('button', { name: 'M4A' })
@@ -134,7 +140,7 @@ test.describe('settings - audio format', () => {
     })
 
     test('switch back to MP3', async ({ page }) => {
-        await login(page)
+        await login(page, SETTINGS_USERNAME, SETTINGS_PASSWORD)
         await page.goto(routes.settings)
 
         await page.getByRole('button', { name: 'M4A' }).click()
@@ -148,7 +154,7 @@ test.describe('settings - audio format', () => {
     })
 
     test('format preference included in download request body', async ({ page }) => {
-        await login(page)
+        await login(page, SETTINGS_USERNAME, SETTINGS_PASSWORD)
         await page.goto(routes.settings)
         await page.getByRole('button', { name: 'M4A' }).click()
         await expect(page.getByRole('button', { name: 'M4A' })).toHaveClass(/bg-sky-500/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.5.5",
+  "version": "0.5.6",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Summary
- Search threshold lowered to 1 character for songbird library instant results
- Debounce-settled + isFetching guard prevents "no matches" flash during typing
- Compact empty state: "no matches in library · search iTunes for X →"
- Invalidate songbird search after download so new songs appear in "In Songbird's Library" immediately

Closes #38.

## Test plan
- [x] No "no matches" flash during typing
- [x] New downloads appear in songbird results after completion
- [x] Library add updates bookmark icon
- [ ] CI passes