### PR TITLE
fix: set maxAge on refreshed access_token cookie in middleware

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -58,7 +58,7 @@ export async function middleware(request: NextRequest) {
       const requestHeaders = new Headers(request.headers)
       requestHeaders.set('cookie', `access_token=${newToken}; ${cookieStr}`)
       const response = NextResponse.next({ request: { headers: requestHeaders } })
-      response.cookies.set('access_token', newToken, { httpOnly: true, sameSite: 'lax', path: '/' })
+      response.cookies.set('access_token', newToken, { httpOnly: true, sameSite: 'lax', path: '/', maxAge: 15 * 60 })
       return response
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Root cause

When the Next.js middleware refreshed an expired access token, it was setting the new cookie without `maxAge`, making it a session cookie (deleted on browser close).

## Changes

- `middleware.ts`: add `maxAge: 15 * 60` to the refreshed access_token cookie

Companion to cboin1996/songbirdapi#26 which fixes the login/refresh endpoints.

## Test plan
- [ ] Login, close browser, reopen — should stay logged in for up to 7 days
- [ ] Cookie in devtools should show expiry date, not "Session"