### PR TITLE
fix: iOS modal cut-off, album to playlist, auth cookie persistence

### DIFF
--- a/app/(authed)/library/library-list.tsx
+++ b/app/(authed)/library/library-list.tsx
@@ -178,6 +178,7 @@ export default function LibraryList() {
     const [bulkLoading, setBulkLoading] = useState(false)
     const [bulkPlaylistPicking, setBulkPlaylistPicking] = useState(false)
     const [albumModal, setAlbumModal] = useState<LibraryAlbum | null>(null)
+    const [albumPlaylistOpen, setAlbumPlaylistOpen] = useState(false)
     const [activeLetter, setActiveLetter] = useState<string | null>(null)
     const [scrubLetter, setScrubLetter] = useState<string | null>(null)
     const scrubbing = useRef(false)
@@ -598,6 +599,19 @@ export default function LibraryList() {
         const ctx = { label: album.collectionName, href: `${routes.library}?view=albums&album=${album.collectionId}`, id: ctxId }
         const queue = album.songs.filter(s => s.properties).map(s => ({ uuid: s.uuid, properties: s.properties!, last_position: s.last_position, last_played_at: s.last_played_at, artwork_cached: s.artwork_cached, source: ctx }))
         play({ uuid: first.uuid, properties: first.properties, last_position: first.last_position, last_played_at: first.last_played_at, artwork_cached: first.artwork_cached, source: ctx }, queue, ctx)
+    }
+
+    async function handleAlbumAddToPlaylist(playlistId: string) {
+        if (!albumModal) return
+        setAlbumPlaylistOpen(false)
+        const songIds = albumModal.songs.map(s => s.uuid)
+        try {
+            await bulkAddSongsToPlaylist(playlistId, songIds)
+            await refreshPlaylists()
+            showToast(`added ${songIds.length} song${songIds.length !== 1 ? 's' : ''} to playlist`)
+        } catch {
+            showToast('failed to add to playlist', true)
+        }
     }
 
     function enterSelectMode(songId?: string) {
@@ -1182,12 +1196,36 @@ export default function LibraryList() {
                 </div>
             )}
 
-            {/* album modal (read-only) */}
+            {/* album modal */}
             <SongPickerModal
                 open={!!albumModal}
-                onClose={() => setAlbumModal(null)}
+                onClose={() => { setAlbumModal(null); setAlbumPlaylistOpen(false) }}
                 title={albumModal?.collectionName ?? ''}
-                titleActions={undefined}
+                titleActions={
+                    playlists.length > 0 ? (
+                        <div className="relative">
+                            <button
+                                onClick={() => setAlbumPlaylistOpen(p => !p)}
+                                className="text-xs text-sky-500 hover:text-sky-400 font-medium px-2 py-1 rounded"
+                            >
+                                + playlist
+                            </button>
+                            {albumPlaylistOpen && (
+                                <div className="absolute right-0 top-full mt-1 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-700 rounded-xl shadow-xl overflow-hidden min-w-[160px] z-10">
+                                    {playlists.map(pl => (
+                                        <button
+                                            key={pl.id}
+                                            onClick={() => handleAlbumAddToPlaylist(pl.id)}
+                                            className="w-full text-left px-4 py-2.5 text-sm text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 touch-manipulation"
+                                        >
+                                            {pl.name}
+                                        </button>
+                                    ))}
+                                </div>
+                            )}
+                        </div>
+                    ) : undefined
+                }
                 songs={albumModal?.songs.map(s => ({ uuid: s.uuid, properties: s.properties, artwork_cached: s.artwork_cached })) ?? []}
                 emptyState="no songs"
                 testId="album-modal"

--- a/app/components/song-picker-modal.tsx
+++ b/app/components/song-picker-modal.tsx
@@ -140,10 +140,10 @@ export default function SongPickerModal({
     if (!open) return null
 
     const body = (
-        <div data-testid={testId} className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center">
+        <div data-testid={testId} className="fixed inset-x-0 top-0 bottom-[var(--player-bar-h,88px)] sm:inset-0 z-[80] flex items-end sm:items-center justify-center">
             {/* backdrop */}
             <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-            <div className="relative z-10 w-full sm:w-[480px] max-h-[85svh] sm:max-h-[85vh] mb-[var(--player-bar-h,88px)] sm:mb-0 flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
+            <div className="relative z-10 w-full sm:w-[480px] max-h-[85svh] sm:max-h-[85vh] flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
                 {/* header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 shrink-0">
                     <span className="font-semibold text-sm flex-1 min-w-0 truncate">{title}</span>

--- a/app/components/song-picker-modal.tsx
+++ b/app/components/song-picker-modal.tsx
@@ -143,7 +143,7 @@ export default function SongPickerModal({
         <div data-testid={testId} className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center">
             {/* backdrop */}
             <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-            <div className="relative z-10 w-full sm:w-[480px] max-h-[85vh] flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
+            <div className="relative z-10 w-full sm:w-[480px] max-h-[85svh] sm:max-h-[85vh] flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
                 {/* header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 shrink-0">
                     <span className="font-semibold text-sm flex-1 min-w-0 truncate">{title}</span>

--- a/app/components/song-picker-modal.tsx
+++ b/app/components/song-picker-modal.tsx
@@ -143,7 +143,7 @@ export default function SongPickerModal({
         <div data-testid={testId} className="fixed inset-0 z-[80] flex items-end sm:items-center justify-center">
             {/* backdrop */}
             <div className="absolute inset-0 bg-black/40 backdrop-blur-sm" onClick={onClose} />
-            <div className="relative z-10 w-full sm:w-[480px] max-h-[85svh] sm:max-h-[85vh] flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
+            <div className="relative z-10 w-full sm:w-[480px] max-h-[85svh] sm:max-h-[85vh] mb-[var(--player-bar-h,88px)] sm:mb-0 flex flex-col bg-white dark:bg-gray-900 rounded-t-2xl sm:rounded-2xl shadow-2xl overflow-hidden">
                 {/* header */}
                 <div className="flex items-center justify-between px-4 py-3 border-b border-gray-100 dark:border-gray-800 shrink-0">
                     <span className="font-semibold text-sm flex-1 min-w-0 truncate">{title}</span>

--- a/middleware.ts
+++ b/middleware.ts
@@ -58,7 +58,7 @@ export async function middleware(request: NextRequest) {
       const requestHeaders = new Headers(request.headers)
       requestHeaders.set('cookie', `access_token=${newToken}; ${cookieStr}`)
       const response = NextResponse.next({ request: { headers: requestHeaders } })
-      response.cookies.set('access_token', newToken, { httpOnly: true, sameSite: 'lax', path: '/' })
+      response.cookies.set('access_token', newToken, { httpOnly: true, sameSite: 'lax', path: '/', maxAge: 15 * 60 })
       return response
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "songbirdweb",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "private": true,
   "scripts": {
     "dev": "next dev --turbopack",


### PR DESCRIPTION
## Changes

- **fix(ui)**: use `svh` on mobile for `SongPickerModal` to prevent iOS bottom sheet being cut off at screen edge (`85vh` → `85svh` on mobile, `85vh` on desktop)
- **feat(library)**: "+ playlist" button in album modal header — adds all album songs to a chosen playlist in one tap
- **fix(auth)**: set `maxAge: 15 * 60` on refreshed `access_token` cookie in middleware so it persists across browser restarts (companion to songbirdapi#26)

## Test plan
- [x] iOS: open album modal in library — songs should not be cut off at bottom
- [x] Library → Albums → tap album → "+ playlist" button appears if playlists exist → pick one → toast confirms
- [x] Log in, close browser, reopen — should stay logged in (cookie expiry in devtools should show a date, not "Session")